### PR TITLE
split index fix

### DIFF
--- a/pahfit/base.py
+++ b/pahfit/base.py
@@ -367,7 +367,7 @@ class PAHFITBase():
         """
         # get the table format
         if tformat is None:
-            tformat = filename.split('.')[1]
+            tformat = filename.split('.')[-1]
 
         # Reading the input file as table
         t = Table.read(filename, format=tformat)

--- a/scripts/run_pahfit
+++ b/scripts/run_pahfit
@@ -61,7 +61,7 @@ if __name__ == '__main__':
                 'Input spectrumfile {} not found'.format(specfile))
 
     # get the table format (from extension of filename)
-    tformat = specfile.split('.')[1]
+    tformat = specfile.split('.')[-1]
     obs_spectrum = Table.read(specfile, format=tformat)
     obs_x = obs_spectrum['wavelength'].to(u.micron,
                                           equivalencies=u.spectral())


### PR DESCRIPTION
This PR fixes the split index bug. Now pahfit will run for all ipac input spectra without errors. However, txt/ascii formats will still raise an error due to either the 'txt' extension or absence of units in the header.