### PR TITLE
Add starting point

### DIFF
--- a/pahfit/base.py
+++ b/pahfit/base.py
@@ -591,7 +591,7 @@ class PAHFITBase:
         sp = interpolate.splrep(obs_x, obs_y)
         for i, (fix, temp) in enumerate(zip(param_info[0]['amps_fixed'], param_info[0]['temps'])):
 
-            if (fix is False) & (temp >= 2500):  # stellar comoponent is defined by BB that has T>=2500
+            if (fix is False) & (temp >= 2500):  # stellar comoponent is defined by BB that has T>=2500 K
                 bb = BlackBody1D(1, temp)
                 if min(obs_x) < 5:
                     lam = min(obs_x) + 0.1  # the wavelength used to compare

--- a/pahfit/base.py
+++ b/pahfit/base.py
@@ -89,6 +89,9 @@ class PAHFITBase:
 
     Parameters
     ----------
+    obs_x and obs_y: np.array
+        the input spectrum
+
     filename: string
         filename giving the pack that contains all the
         info described for param_info
@@ -124,7 +127,7 @@ class PAHFITBase:
             param_info = self.read(filename, tformat=tformat)
 
         # guess values and update starting point (if not set fixed) based on the input spectrum
-        param_info = self.starting_point(obs_x, obs_y, param_info)
+        param_info = self.guess(obs_x, obs_y, param_info)
 
         bb_info = param_info[0]
         dust_features = param_info[1]
@@ -570,16 +573,25 @@ class PAHFITBase:
 
         return readout
 
-    def starting_point(self, obs_x, obs_y, param_info):
+    @staticmethod
+    def guess(obs_x, obs_y, param_info):
         """
-        return updated starting point in param_info based on the input spectrum
+        Guess and return updated starting point in param_info based on the input spectrum.
+
+        Parameters
+        ----------
+        obs_x and obs_y: np.array
+            input spectrum
+
+        param_info: tuple of dics
+            The dictonaries contain info for each type of component.
         """
 
         # guess starting point of bb
         sp = interpolate.splrep(obs_x, obs_y)
         for i, (fix, temp) in enumerate(zip(param_info[0]['amps_fixed'], param_info[0]['temps'])):
 
-            if (fix is False) & (i == 0):  # BB0 - stellar comoponent measured at 5.5 um
+            if (fix is False) & (temp >= 2500):  # stellar comoponent is defined by BB that has T>=2500
                 bb = BlackBody1D(1, temp)
                 if min(obs_x) < 5:
                     lam = min(obs_x) + 0.1  # the wavelength used to compare

--- a/pahfit/base.py
+++ b/pahfit/base.py
@@ -579,7 +579,7 @@ class PAHFITBase:
         sp = interpolate.splrep(obs_x, obs_y)
         for i, (fix, temp) in enumerate(zip(param_info[0]['amps_fixed'], param_info[0]['temps'])):
 
-            if (fix == False) & (i == 0):  # BB0 - stellar comoponent measured at 5.5 um
+            if (fix is False) & (i == 0):  # BB0 - stellar comoponent measured at 5.5 um
                 bb = BlackBody1D(1, temp)
                 if min(obs_x) < 5:
                     lam = min(obs_x) + 0.1  # the wavelength used to compare
@@ -589,7 +589,7 @@ class PAHFITBase:
                     y_lam = interpolate.splev(5.5, sp)
                     amp_guess = y_lam / bb(5.5)
 
-            elif fix == False:
+            elif fix is False:
                 fmax_lam = 2898. / temp
                 bb = BlackBody1D(1, temp)
                 if (fmax_lam >= min(obs_x)) & (fmax_lam <= max(obs_x)):
@@ -613,7 +613,7 @@ class PAHFITBase:
         # dust
         for i, fix in enumerate(param_info[1]['amps_fixed']):
 
-            if fix == False:
+            if fix is False:
                 amp_guess = 0.2 * np.median(obs_y)
 
             param_info[1]['amps'][i] = amp_guess
@@ -621,7 +621,7 @@ class PAHFITBase:
         # h2
         for i, fix in enumerate(param_info[2]['amps_fixed']):
 
-            if fix == False:
+            if fix is False:
                 amp_guess = 0.2 * np.median(obs_y)
 
             param_info[2]['amps'][i] = amp_guess
@@ -629,7 +629,7 @@ class PAHFITBase:
         # ion
         for i, fix in enumerate(param_info[3]['amps_fixed']):
 
-            if fix == False:
+            if fix is False:
                 amp_guess = 0.2 * np.median(obs_y)
 
             param_info[3]['amps'][i] = amp_guess

--- a/pahfit/tests/test_classic_pack.py
+++ b/pahfit/tests/test_classic_pack.py
@@ -29,10 +29,8 @@ def test_classic_pack():
                                           equivalencies=u.spectral())
     obs_y = obs_spectrum['flux'].to(u.Jy,
                                     equivalencies=u.spectral_density(obs_x))
-    obs_x = obs_x.value
-    obs_y = obs_y.value
 
-    pmodel = PAHFITBase(obs_x, obs_y, filename=packfilename, tformat='ipac')
+    pmodel = PAHFITBase(obs_x.value, obs_y.value, filename=packfilename, tformat='ipac')
     # read in the file and get the param_info
     nparam_info = pmodel.read(packfilename, tformat='ipac')
 

--- a/pahfit/tests/test_classic_pack.py
+++ b/pahfit/tests/test_classic_pack.py
@@ -19,7 +19,7 @@ def test_classic_pack():
     # now read in the equivalent info from a file
     path = pkg_resources.resource_filename('pahfit', 'packs/')
     packfilename = '{}/scipack_ExGal_SpitzerIRSSLLL.ipac'.format(path)
-    pmodel = PAHFITBase(filename=packfilename, tformat='ipac')
+    pmodel = PAHFITBase(obs_x, obs_y, filename=packfilename, tformat='ipac')
     # read in the file and get the param_info
     nparam_info = pmodel.read(packfilename, tformat='ipac')
 

--- a/pahfit/tests/test_classic_pack.py
+++ b/pahfit/tests/test_classic_pack.py
@@ -1,6 +1,7 @@
 import numpy as np
 
 import pkg_resources
+import astropy.units as u
 
 from pahfit.PAHFIT_Spitzer_Exgal import (InstPackSpitzerIRSSLLL, SciPackExGal)
 from pahfit.base import PAHFITBase
@@ -17,8 +18,19 @@ def test_classic_pack():
                    sci_pack.att_info)
 
     # now read in the equivalent info from a file
-    path = pkg_resources.resource_filename('pahfit', 'packs/')
-    packfilename = '{}/scipack_ExGal_SpitzerIRSSLLL.ipac'.format(path)
+    path_packs = pkg_resources.resource_filename('pahfit', 'packs/')
+    packfilename = '{}/scipack_ExGal_SpitzerIRSSLLL.ipac'.format(path_packs)
+    path_data = pkg_resources.resource_filename('pahfit', 'data/')
+    datafilename = '{}/M101_Nucleus_irs.ipac'.format(path_data)
+
+    obs_spectrum = Table.read(datafilename, format='ipac')
+    obs_x = obs_spectrum['wavelength'].to(u.micron,
+                                          equivalencies=u.spectral())
+    obs_y = obs_spectrum['flux'].to(u.Jy,
+                                    equivalencies=u.spectral_density(obs_x))
+    obs_x = obs_x.value
+    obs_y = obs_y.value
+
     pmodel = PAHFITBase(obs_x, obs_y, filename=packfilename, tformat='ipac')
     # read in the file and get the param_info
     nparam_info = pmodel.read(packfilename, tformat='ipac')

--- a/pahfit/tests/test_classic_pack.py
+++ b/pahfit/tests/test_classic_pack.py
@@ -2,6 +2,7 @@ import numpy as np
 
 import pkg_resources
 import astropy.units as u
+from astropy.table import Table
 
 from pahfit.PAHFIT_Spitzer_Exgal import (InstPackSpitzerIRSSLLL, SciPackExGal)
 from pahfit.base import PAHFITBase

--- a/scripts/run_pahfit
+++ b/scripts/run_pahfit
@@ -75,7 +75,7 @@ if __name__ == '__main__':
     # strip units as the observed spectrum is in the internal units
     obs_x = obs_x.value
     obs_y = obs_y.value
-    weights = 1./obs_unc.value
+    weights = 1. / obs_unc.value
 
     # read in the pack file
     packfile = args.packfile
@@ -87,14 +87,14 @@ if __name__ == '__main__':
         else:
             raise ValueError('Input packfile {} not found'.format(packfile))
 
-    pmodel = PAHFITBase(filename=packfile)
+    pmodel = PAHFITBase(obs_x, obs_y, filename=packfile)
 
     # pick the fitter
     fit = LevMarLSQFitter()
 
     # fit
     obs_fit = fit(pmodel.model, obs_x, obs_y, weights=weights,
-                  maxiter=1000)
+                  maxiter=400)
     print(fit.fit_info['message'])
 
     # save results to fits file

--- a/scripts/run_pahfit
+++ b/scripts/run_pahfit
@@ -94,7 +94,7 @@ if __name__ == '__main__':
 
     # fit
     obs_fit = fit(pmodel.model, obs_x, obs_y, weights=weights,
-                  maxiter=400)
+                  maxiter=1000)
     print(fit.fit_info['message'])
 
     # save results to fits file


### PR DESCRIPTION
Adding the function -- starting_point in base.py, which takes the input spectrum and guesses the starting points of the components' amplitude, based on the suggestions in #82. Note that this function will not be applied if amp_fixed in each component is set to be True in the science pack file. 