### PR TITLE
Fit parameters to match IDL mpfitfun

### DIFF
--- a/scripts/run_pahfit
+++ b/scripts/run_pahfit
@@ -94,7 +94,7 @@ if __name__ == '__main__':
 
     # fit
     obs_fit = fit(pmodel.model, obs_x, obs_y, weights=weights,
-                  maxiter=1000)
+                  maxiter=200, epsilon=1e-10, acc=1e-10)
     print(fit.fit_info['message'])
 
     # save results to fits file


### PR DESCRIPTION
For v2.0, the goal is to have the python version to be very similar to the IDL version.  One area for this is the parameters that impact the quality and speed of the fit.  Read the doc for [mpfitfun.pro](https://pages.physics.wisc.edu/~craigm/idl/down/mpfitfun.pro) and the docs for the astropy [LevMarLSQFitter](https://docs.astropy.org/en/stable/api/astropy.modeling.fitting.LevMarLSQFitter.html) and the called the scipy [leastsq](https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.leastsq.html#scipy.optimize.leastsq).  To my understanding the max number of iterations (200) and tolerances (1e-10) needed to be set.

Closes #84.