### PR TITLE
Switch to simple scipy.interpolate.interp1d interpolation 

### DIFF
--- a/pahfit/base.py
+++ b/pahfit/base.py
@@ -587,27 +587,26 @@ class PAHFITBase:
             The dictonaries contain info for each type of component.
         """
 
+        # simple linear interpolation function for spectrum
+        sp = interpolate.interp1d(obs_x, obs_y)
+
         # guess starting point of bb
-        sp = interpolate.splrep(obs_x, obs_y)
         for i, (fix, temp) in enumerate(zip(param_info[0]['amps_fixed'], param_info[0]['temps'])):
 
             if (fix is False) & (temp >= 2500):  # stellar comoponent is defined by BB that has T>=2500 K
                 bb = BlackBody1D(1, temp)
                 if min(obs_x) < 5:
                     lam = min(obs_x) + 0.1  # the wavelength used to compare
-                    y_lam = interpolate.splev(lam, sp)
-                    amp_guess = y_lam / bb(lam)
                 else:  # if min(obs_x) > 5, use 5.5 um
-                    y_lam = interpolate.splev(5.5, sp)
-                    amp_guess = y_lam / bb(5.5)
+                    lam = 5.5
+                amp_guess = sp(lam) / bb(lam)
 
             elif fix is False:
                 fmax_lam = 2898. / temp
                 bb = BlackBody1D(1, temp)
                 if (fmax_lam >= min(obs_x)) & (fmax_lam <= max(obs_x)):
                     lam = fmax_lam
-                    y_lam = interpolate.splev(lam, sp)
-                    amp_guess = y_lam / bb(lam) * 0.2
+                    amp_guess = sp(lam) / bb(lam) * 0.2
                 elif (fmax_lam > max(obs_x)):
                     lam = max(obs_x)
                     amp_guess = obs_y[np.argmax(obs_x)] / bb(lam) * 0.2

--- a/pahfit/component_models.py
+++ b/pahfit/component_models.py
@@ -79,9 +79,11 @@ class S07_attenuation(Fittable1DModel):
         spline_x = np.concatenate([kvt_wav_short, kvt_wav])
         spline_y = np.concatenate([kvt_int_short, kvt_int])
 
-        spline_rep = interpolate.splrep(spline_x, spline_y)
+        # spline_rep = interpolate.splrep(spline_x, spline_y)
+        intfunc = interpolate.interp1d(spline_x, spline_y)
         in_x_spline = in_x[in_x < max(kvt_wav)]
-        new_spline_y = interpolate.splev(in_x_spline, spline_rep, der=0)
+        # new_spline_y = interpolate.splev(in_x_spline, spline_rep, der=0)
+        new_spline_y = intfunc(in_x_spline)
 
         nf = Drude1D(amplitude=0.4, x_0=18.0, fwhm=0.247 * 18.0)
         in_x_drude = in_x[in_x >= max(kvt_wav)]

--- a/scripts/plot_pahfit
+++ b/scripts/plot_pahfit
@@ -26,7 +26,7 @@ def initialize_parser():
     parser = argparse.ArgumentParser()
     parser.add_argument('spectrumfile',
                         help='name of file with observed spectrum')
-    parser.add_argument('filename', help='name of PAHFIT results file')
+    parser.add_argument('fitfilename', help='name of PAHFIT results file')
     parser.add_argument('--savefig', action='store',
                         default=None, choices=plottypes,
                         help='Save figure to a file of specified type')
@@ -70,7 +70,7 @@ if __name__ == "__main__":
     obs_y = obs_y.value
 
     # read in the PAHFIT results
-    pmodel = PAHFITBase(filename=args.filename)
+    pmodel = PAHFITBase(obs_x, obs_y, filename=args.fitfilename)
 
     # plot result
     fontsize = 18


### PR DESCRIPTION
In guess and the S07_att component, switch from spline interpolation to a more simple linear interpolation.  This fixes a bug in fitting the NGC 2023.  The NGC 2023 spectrum looked fine.  No idea why the spline interpolation didn't work (maybe something about the wavelength spacing of the spectrum?).  But simple linear interpolation should be fine.

Closes #97.

Also fixed a minor bug in plot_pahfit to update it to include passing the observed spectrum when defining the PAHFIT model.