### PR TITLE
PAHFIT_v2.1

### DIFF
--- a/pahfit/base.py
+++ b/pahfit/base.py
@@ -1,6 +1,6 @@
 from astropy.modeling.functional_models import Gaussian1D
 
-from pahfit.component_models import BlackBody1D, S07_attenuation
+from pahfit.component_models import BlackBody1D, S07_attenuation, att_Drude1D
 
 from astropy.table import Table, vstack
 from astropy.modeling.physical_models import Drude1D
@@ -242,6 +242,54 @@ class PAHFITBase:
             fixed={"tau_sil": att_info["amps_fixed"][0]},
         )
 
+        # add additional att components to the model if necessary
+        # Note: perhaps can be improved to make it more concise by
+        #       encorporating them into a for loop
+        if 'tau_H2O' in att_info["names"]:
+            self.model *= att_Drude1D(
+                name=att_info["names"][1],
+                tau=att_info["amps"][1],
+                x_0=att_info["x_0"][1],
+                fwhm=att_info["fwhms"][1],
+                bounds={
+                    "tau": att_info["amps_limits"][1],
+                    "fwhm": att_info["fwhms_limits"][1],
+                },
+                fixed={
+                    "x_0": att_info["x_0_fixed"][1],
+                },
+            )
+
+        if 'tau_CO2' in att_info["names"]:
+            self.model *= att_Drude1D(
+                name=att_info["names"][2],
+                tau=att_info["amps"][2],
+                x_0=att_info["x_0"][2],
+                fwhm=att_info["fwhms"][2],
+                bounds={
+                    "tau": att_info["amps_limits"][2],
+                    "fwhm": att_info["fwhms_limits"][2],
+                },
+                fixed={
+                    "x_0": att_info["x_0_fixed"][2],
+                },
+            )
+
+        if 'tau_CO' in att_info["names"]:
+            self.model *= att_Drude1D(
+                name=att_info["names"][3],
+                tau=att_info["amps"][3],
+                x_0=att_info["x_0"][3],
+                fwhm=att_info["fwhms"][3],
+                bounds={
+                    "tau": att_info["amps_limits"][3],
+                    "fwhm": att_info["fwhms_limits"][3],
+                },
+                fixed={
+                    "x_0": att_info["x_0_fixed"][3],
+                },
+            )
+
     def plot(self, ax, x, y, model):
         """
         Plot model using axis object.
@@ -260,11 +308,28 @@ class PAHFITBase:
         ax.plot(x, model(x) / x, "g-")
         ax.plot(x, y / x, "ks", fillstyle="none")
 
+        ax_att = ax.twinx()  # axis for plotting the extinction curve
+
         # get the extinction model (probably a better way to do this)
         for cmodel in model:
             if isinstance(cmodel, S07_attenuation):
-                ax.plot(x, cmodel(x) * max(y / x), "k--")
-                ext_model = cmodel(x)
+                ext_components_S07 = cmodel
+
+        # get additional extinction components that can be
+        # characterized by functional forms (Drude profile in this case)
+        ext_components_funct = []
+        for cmodel in model:
+            if isinstance(cmodel, att_Drude1D):
+                ext_components_funct.append(cmodel)
+        ext_funct_model = ext_components_funct[0]
+        for cmodel in ext_components_funct[1:]:
+            ext_funct_model *= cmodel
+
+        ext_model = ext_components_S07(x) * ext_funct_model(x)
+
+        ax_att.plot(x, ext_model, "k--")
+        ax_att.set_ylabel("Attenuation")
+        ax_att.set_ylim(0, 1.1)
 
         # create the continum compound model (base for plotting lines)
         cont_components = []
@@ -370,6 +435,42 @@ class PAHFITBase:
             dtype=("U25", "U25", "float64", "float64", "float64", "bool"),
         )
 
+        # attenuation components that can be characterized by a functional form
+        att_funct_table = Table(
+            names=(
+                "Name",
+                "Form",
+                "x_0",
+                "x_0_min",
+                "x_0_max",
+                "x_0_fixed",
+                "amp",
+                "amp_min",
+                "amp_max",
+                "amp_fixed",
+                "fwhm",
+                "fwhm_min",
+                "fwhm_max",
+                "fwhm_fixed",
+            ),
+            dtype=(
+                "U25",
+                "U25",
+                "float64",
+                "float64",
+                "float64",
+                "bool",
+                "float64",
+                "float64",
+                "float64",
+                "bool",
+                "float64",
+                "float64",
+                "float64",
+                "bool",
+            ),
+        )
+
         for component in obs_fit:
             comp_type = component.__class__.__name__
 
@@ -438,8 +539,28 @@ class PAHFITBase:
                     ]
                 )
 
+            elif comp_type == "att_Drude1D":
+                att_funct_table.add_row(
+                    [
+                        component.name,
+                        comp_type,
+                        component.x_0.value,
+                        component.x_0.bounds[0],
+                        component.x_0.bounds[1],
+                        component.x_0.fixed,
+                        component.tau.value,
+                        component.tau.bounds[0],
+                        component.tau.bounds[1],
+                        component.tau.fixed,
+                        component.fwhm.value,
+                        component.fwhm.bounds[0],
+                        component.fwhm.bounds[1],
+                        component.fwhm.fixed,
+                    ]
+                )
+
         # stack the tables (handles missing columns between tables)
-        out_table = vstack([bb_table, line_table, att_table])
+        out_table = vstack([bb_table, line_table, att_table, att_funct_table])
 
         # Writing output table
         out_table.write(
@@ -475,7 +596,7 @@ class PAHFITBase:
         bb_ind = np.concatenate(np.argwhere(t["Form"] == "BlackBody1D"))
         df_ind = np.concatenate(np.argwhere(t["Form"] == "Drude1D"))
         ga_ind = np.concatenate(np.argwhere(t["Form"] == "Gaussian1D"))
-        at_ind = np.concatenate(np.argwhere(t["Form"] == "S07_attenuation"))
+        at_ind = np.concatenate(np.argwhere((t["Form"] == "S07_attenuation") | (t["Form"] == "att_Drude1D")))
 
         # now split the gas emission lines between H2 and ions
         names = [str(i) for i in np.take(t["Name"], ga_ind)]
@@ -562,11 +683,21 @@ class PAHFITBase:
         # Create the attenuation dict
         att_info = {
             "names": np.array(t["Name"][at_ind].data),
+            "x_0": np.array(t["x_0"][at_ind].data),
+            "x_0_limits": _ingest_limits(
+                t["x_0_min"][at_ind].data, t["x_0_max"][at_ind].data
+            ),
+            "x_0_fixed": _ingest_fixed(t["x_0_fixed"][at_ind].data),
             "amps": np.array(t["amp"][at_ind].data),
             "amps_limits": _ingest_limits(
                 t["amp_min"][at_ind].data, t["amp_max"][at_ind].data
             ),
             "amps_fixed": _ingest_fixed(t["amp_fixed"][at_ind].data),
+            "fwhms": np.array(t["fwhm"][at_ind].data),
+            "fwhms_limits": _ingest_limits(
+                t["fwhm_min"][at_ind].data, t["fwhm_max"][at_ind].data
+            ),
+            "fwhms_fixed": _ingest_fixed(t["fwhm_fixed"][at_ind].data),
         }
 
         # Create output tuple

--- a/pahfit/component_models.py
+++ b/pahfit/component_models.py
@@ -5,7 +5,7 @@ from astropy.modeling import Fittable1DModel
 from astropy.modeling import Parameter
 
 
-__all__ = ["BlackBody1D", "S07_attenuation"]
+__all__ = ["BlackBody1D", "S07_attenuation", "att_Drude1D"]
 
 
 class BlackBody1D(Fittable1DModel):
@@ -102,4 +102,22 @@ class S07_attenuation(Fittable1DModel):
             return np.full((len(in_x)), 0.0)
         else:
             tau_x = tau_si * self.kvt(in_x)
+            return (1.0 - np.exp(-1.0 * tau_x)) / tau_x
+
+
+class att_Drude1D(Fittable1DModel):
+    """
+    Attenuation components that can be parameterized by Drude profiles.
+    """
+    tau = Parameter()
+    x_0 = Parameter()
+    fwhm = Parameter()
+
+    @staticmethod
+    def evaluate(x, tau, x_0, fwhm):
+        if tau == 0.0:
+            return np.full((len(x)), 0.0)
+        else:
+            profile = Drude1D(amplitude=1.0, fwhm=fwhm, x_0=x_0)
+            tau_x = tau * profile(x)
             return (1.0 - np.exp(-1.0 * tau_x)) / tau_x

--- a/pahfit/packs/scipack_ExGal_AkariIRC+SpitzerIRSSLLL.ipac
+++ b/pahfit/packs/scipack_ExGal_AkariIRC+SpitzerIRSSLLL.ipac
@@ -1,0 +1,70 @@
+|     Name|           Form|  temp|temp_min|temp_max|temp_fixed|   amp|amp_min|amp_max|amp_fixed|     x_0| x_0_min| x_0_max|x_0_fixed|   fwhm|fwhm_min|fwhm_max|fwhm_fixed|
+|     char|           char|double|  double|  double|      char|double| double| double|     char|  double|  double|  double|     char| double|  double|  double|      char|
+|         |               |      |        |        |          |      |       |       |         |        |        |        |         |       |        |        |          |
+|     null|           null|  null|    null|    null|      null|  null|   null|   null|     null|    null|    null|    null|     null|   null|    null|    null|      null|
+       BB0     BlackBody1D 5000.0      0.0      nan       True  1e-11     0.0     nan     False     null     null     null      null    null     null     null       null
+       BB1     BlackBody1D 1500.0      0.0      nan       True  1e-10     0.0     nan     False     null     null     null      null    null     null     null       null 
+       BB2     BlackBody1D  800.0      0.0      nan       True  1e-10     0.0     nan     False     null     null     null      null    null     null     null       null 
+       BB3     BlackBody1D  300.0      0.0      nan       True  1e-10     0.0     nan     False     null     null     null      null    null     null     null       null
+       BB4     BlackBody1D  200.0      0.0      nan       True  1e-10     0.0     nan     False     null     null     null      null    null     null     null       null
+       BB5     BlackBody1D  135.0      0.0      nan       True  1e-10     0.0     nan     False     null     null     null      null    null     null     null       null
+       BB6     BlackBody1D   90.0      0.0      nan       True  1e-10     0.0     nan     False     null     null     null      null    null     null     null       null
+       BB7     BlackBody1D   65.0      0.0      nan       True  1e-10     0.0     nan     False     null     null     null      null    null     null     null       null
+       BB8     BlackBody1D   50.0      0.0      nan       True  1e-10     0.0     nan     False     null     null     null      null    null     null     null       null
+       BB9     BlackBody1D   40.0      0.0      nan       True  1e-10     0.0     nan     False     null     null     null      null    null     null     null       null
+      BB10     BlackBody1D   35.0      0.0      nan       True  1e-10     0.0     nan     False     null     null     null      null    null     null     null       null
+       DF0         Drude1D   null     null     null       null    0.5     0.0     nan     False     3.29     3.27     3.33     False  0.0418  0.03762   0.0836      False 
+       DF1         Drude1D   null     null     null       null    0.5     0.0     nan     False     3.40     3.39     3.41     False  0.0299  0.02394  0.05984      False 
+       DF2         Drude1D   null     null     null       null    0.5     0.0     nan     False     3.47      nan      nan      True  0.1000      nan      nan       True 
+       DF3         Drude1D   null     null     null       null    0.5     0.0     nan     False    5.242     4.72     5.76      True 0.05766 0.051896 0.063428       True 
+       DF4         Drude1D   null     null     null       null    0.5     0.0     nan     False    5.329     4.80     5.86      True 0.04263 0.038369 0.046895       True   
+       DF5         Drude1D   null     null     null       null  100.0     0.0     nan     False      5.7     5.60      5.8      True  0.1995  0.17955  0.21945       True
+       DF6         Drude1D   null     null     null       null  100.0     0.0     nan     False     6.22     6.12     6.32      True  0.1866  0.16794  0.20526       True
+       DF7         Drude1D   null     null     null       null  100.0     0.0     nan     False     6.69     6.59     6.79      True  0.4683  0.42147  0.51513       True
+       DF8         Drude1D   null     null     null       null  100.0     0.0     nan     False     7.42     7.32     7.52      True 0.93492 0.841428 1.028412       True
+       DF9         Drude1D   null     null     null       null  100.0     0.0     nan     False      7.6      7.5     7.70      True  0.3344  0.30096  0.36784       True
+      DF10         Drude1D   null     null     null       null  100.0     0.0     nan     False     7.85     7.75     7.95      True 0.41605 0.374445 0.457655       True
+      DF11         Drude1D   null     null     null       null  100.0     0.0     nan     False     8.33     8.23     8.43      True  0.4165  0.37485  0.45815       True
+      DF12         Drude1D   null     null     null       null  100.0     0.0     nan     False     8.61     8.51     8.71      True 0.33579 0.302211 0.369369       True
+      DF13         Drude1D   null     null     null       null  100.0     0.0     nan     False    10.68    10.58    10.78      True  0.2136  0.19224  0.23496       True
+      DF14         Drude1D   null     null     null       null  100.0     0.0     nan     False    11.23    11.13    11.33      True 0.13476 0.121284 0.148236       True
+      DF15         Drude1D   null     null     null       null  100.0     0.0     nan     False    11.33    11.23    11.43      True 0.36256 0.326304 0.398816       True
+      DF16         Drude1D   null     null     null       null  100.0     0.0     nan     False    11.99    11.89    12.09      True 0.53955 0.485595 0.593505       True
+      DF17         Drude1D   null     null     null       null  100.0     0.0     nan     False    12.62    12.52    12.72      True 0.53004 0.477036 0.583044       True
+      DF18         Drude1D   null     null     null       null  100.0     0.0     nan     False    12.69    12.59    12.79      True 0.16497 0.148473 0.181467       True
+      DF19         Drude1D   null     null     null       null  100.0     0.0     nan     False    13.48    13.38    13.58      True  0.5392  0.48528  0.59312       True
+      DF20         Drude1D   null     null     null       null  100.0     0.0     nan     False    14.04    13.94    14.14      True 0.22464 0.202176 0.247104       True
+      DF21         Drude1D   null     null     null       null  100.0     0.0     nan     False    14.19    14.09    14.29      True 0.35475 0.319275 0.390225       True
+      DF22         Drude1D   null     null     null       null  100.0     0.0     nan     False     15.9     15.8     16.0      True   0.318   0.2862   0.3498       True
+      DF23         Drude1D   null     null     null       null  100.0     0.0     nan     False    16.45    16.35    16.55      True  0.2303  0.20727  0.25333       True
+      DF24         Drude1D   null     null     null       null  100.0     0.0     nan     False    17.04    16.94    17.14      True  1.1076  0.99684  1.21836       True
+      DF25         Drude1D   null     null     null       null  100.0     0.0     nan     False   17.375   17.275   17.475      True  0.2085  0.18765  0.22935       True
+      DF26         Drude1D   null     null     null       null  100.0     0.0     nan     False    17.87    17.77    17.97      True 0.28592 0.257328 0.314512       True
+      DF27         Drude1D   null     null     null       null  100.0     0.0     nan     False    18.92    18.82    19.02      True 0.35948 0.323532 0.395428       True
+      DF28         Drude1D   null     null     null       null  100.0     0.0     nan     False     33.1     33.0     33.2      True   1.655   1.4895   1.8205       True
+   H2 S(7)      Gaussian1D   null     null     null       null  100.0     0.0     nan     False   5.5115   5.4615   5.5615     False   0.053   0.0265   0.0795      False
+   H2 S(6)      Gaussian1D   null     null     null       null  100.0     0.0     nan     False   6.1088   6.0588   6.1588     False   0.053   0.0265   0.0795      False
+   H2 S(5)      Gaussian1D   null     null     null       null  100.0     0.0     nan     False   6.9091   6.8591   6.9591     False   0.053   0.0265   0.0795      False
+   H2 S(4)      Gaussian1D   null     null     null       null  100.0     0.0     nan     False   8.0258   7.9758   8.0758     False     0.1     0.05     0.15      False
+   H2 S(3)      Gaussian1D   null     null     null       null  100.0     0.0     nan     False   9.6649   9.6149   9.7149     False     0.1     0.05     0.15      False
+   H2 S(2)      Gaussian1D   null     null     null       null  100.0     0.0     nan     False  12.2785  12.2285  12.3285     False     0.1     0.05     0.15      False
+   H2 S(1)      Gaussian1D   null     null     null       null  100.0     0.0     nan     False  17.0346  16.9846  17.0846     False    0.14     0.07     0.21      False
+   H2 S(0)      Gaussian1D   null     null     null       null  100.0     0.0     nan     False  28.2207  28.1707  28.2707     False    0.34     0.17     0.51      False
+   Br_beta      Gaussian1D   null     null     null       null    0.5     0.0     nan     False  2.62587     2.52     2.73      True   0.034   0.0265   0.0795       True
+  Pf_gamma      Gaussian1D   null     null     null       null    0.5     0.0     nan     False  3.74056     3.60     3.90      True   0.034   0.0265   0.0795       True
+  Br_alpha      Gaussian1D   null     null     null       null    0.5     0.0     nan     False  4.05226     4.00     4.10      True   0.034   0.0265   0.0795       True 
+   Pf_beta      Gaussian1D   null     null     null       null    0.5     0.0     nan     False  4.65378     4.50     4.80      True   0.034   0.0265   0.0795       True 
+    [ArII]      Gaussian1D   null     null     null       null  100.0     0.0     nan     False 6.985274 6.935274 7.035274     False   0.053   0.0265   0.0795      False
+   [ArIII]      Gaussian1D   null     null     null       null  100.0     0.0     nan     False  8.99138  8.94138  9.04138     False     0.1     0.05     0.15      False
+     [SIV]      Gaussian1D   null     null     null       null  100.0     0.0     nan     False  10.5105  10.4605  10.5605     False     0.1     0.05     0.15      False
+    [NeII]      Gaussian1D   null     null     null       null  100.0     0.0     nan     False   12.813   12.763   12.863     False     0.1     0.05     0.15      False
+   [NeIII]      Gaussian1D   null     null     null       null  100.0     0.0     nan     False   15.555   15.505   15.605     False    0.14     0.07     0.21      False
+ [SIII] 18      Gaussian1D   null     null     null       null  100.0     0.0     nan     False   18.713   18.663   18.763     False    0.14     0.07     0.21      False
+     [OIV]      Gaussian1D   null     null     null       null  100.0     0.0     nan     False    25.91    25.86    25.96     False    0.34     0.17     0.51      False
+    [FeII]      Gaussian1D   null     null     null       null  100.0     0.0     nan     False   25.989   25.939   26.039     False    0.34     0.17     0.51      False
+ [SIII] 33      Gaussian1D   null     null     null       null  100.0     0.0     nan     False    33.48    33.43    33.53     False    0.34     0.17     0.51      False
+    [SiII]      Gaussian1D   null     null     null       null  100.0     0.0     nan     False  34.8152  34.7652  34.8652     False    0.34     0.17     0.51      False
+   S07_att S07_attenuation   null     null     null       null    0.1     0.0    10.0     False     null     null     null      null    null     null     null       null
+   tau_H2O     att_Drude1D   nan       nan      nan       None   0.01     0.0     2.5     False     3.05      nan      nan      True   0.406   0.4056    0.528      False 
+   tau_CO2     att_Drude1D   nan       nan      nan       None    0.1     0.0   1.532     False     4.27      nan      nan      True   0.033   0.0264   0.0396      False
+    tau_CO     att_Drude1D   nan       nan      nan       None    0.4     0.0     0.4     False     4.67      4.5     4.69     False     0.1     0.08     0.12      False


### PR DESCRIPTION
This is a relatively large PR that includes the capability of fitting the combined AKARI+Spitzer spectrum, with a wavelength coverage of 2.5-38 µm. The objective of this PR is to work on #15 that will set the milestone of 2.1.

Recaps on this PR:

- It is a direct translation of the enhanced IDL PAHFIT from Lai et al. (2020). See Table 2 in this paper for detail.
- Adding dust/line emission features and attenuation between 2.5-5 µm.
- The added attenuation components include H2O (3.05 µm), CO2 (4.27 µm), and CO (4.67 µm).
- Updating a new AKARI+Spitzer scipack file (scipack_ExGal_AkariIRC+SpitzerIRSSLLL.ipac).

At this point, I didn't separate AKARI and make it a standalone scipack. May need more discussions and effort to build the pack generator (in relation to the discussion in #88). This can be worked along the way. This PR only focuses on the capability of fitting the AKARI+Spitzer spectrum.

The parameters of features that lie beyond 5 µm in AKARI+Spitzer scipack was set following the Spitzer scipack (scipack_ExGal_SpitzerIRSSLLL.ipac), except (i) PAH feature at 5.27 is split into two features, i.e, PAH 5.24 and PAH 5.33 (ii) the initial value of amp of S07_att is set to 0.1 rather than 1 in scipack_ExGal_SpitzerIRSSLLL.ipac.

Here is a quick look at the result of the 1C spectrum adopted from Lai et al. (2020).
![image](https://user-images.githubusercontent.com/13136763/115430688-9500e500-a1d2-11eb-8d68-549a9c0d21c6.png)
