### PR TITLE
Fix right axis

### DIFF
--- a/pahfit/base.py
+++ b/pahfit/base.py
@@ -258,7 +258,7 @@ class PAHFITBase:
             observed spectrum uncertainties
         model : PAHFITBase model
             model giving all the components and parameters
-        scalefac_resid : integer
+        scalefac_resid : float
             Factor multiplying the standard deviation of the residuals to adjust plot limits
         """
         # spectrum and best fit model

--- a/pahfit/base.py
+++ b/pahfit/base.py
@@ -273,16 +273,11 @@ class PAHFITBase:
         ax_att = ax.twinx()  # axis for plotting the extinction curve
         ax_att.tick_params(direction='in')
 
-        ax_att = ax.twinx()  # axis for plotting the extinction curve
-
         # get the extinction model (probably a better way to do this)
         for cmodel in model:
             if isinstance(cmodel, S07_attenuation):
                 ax_att.plot(x, cmodel(x), "k--")
                 ext_model = cmodel(x)
-        ax_att.set_ylabel("Attenuation")
-        ax_att.set_ylim(0, 1.1)
-
         ax_att.set_ylabel("Attenuation")
         ax_att.set_ylim(0, 1.1)
 


### PR DESCRIPTION
This PR fixes a double entry of the right side attenuation axis introduced after PR #115 merge. This was caused because I included the right side attenuation axis code (introduced in PR #114) independently in PR #115, because PR #115 was created from a branch before the merge of PR #114. 

Probably this is an example where things can be tricky with multiple pending PRs.