### PR TITLE
Update fit_spectrum.rst to clarify where example data can be found

### DIFF
--- a/docs/fit_spectrum.rst
+++ b/docs/fit_spectrum.rst
@@ -13,10 +13,10 @@ A spectrum can be fit from the command line using the ``run_pahfit`` script.
 To run this script, the observed spectrum to be fit and a model pack file
 are specified.
 
-For example, to fit the Spitzer IRS SL/LL spectrum of the M101 nucleus
-(included in the data directory, from
-`Gordon et al. 2008, ApJ, 682, 336 <https://ui.adsabs.harvard.edu/abs/2008ApJ...682..336G/abstract>`_),
-the command is:
+The following command fits the Spitzer IRS SL/LL spectrum of the M101 
+nucleus. This file can be found in the source code's ``pahfit/data`` directory, 
+from
+`Gordon et al. 2008, ApJ, 682, 336 <https://ui.adsabs.harvard.edu/abs/2008ApJ...682..336G/abstract>`_
 
 .. code-block:: console
 

--- a/docs/fit_spectrum.rst
+++ b/docs/fit_spectrum.rst
@@ -14,8 +14,8 @@ To run this script, the observed spectrum to be fit and a model pack file
 are specified.
 
 The following command fits the Spitzer IRS SL/LL spectrum of the M101 
-nucleus. This file can be found in the source code's ``pahfit/data`` directory, 
-from
+nucleus. This file can be found in the source code's ``pahfit/data`` directory
+and is taken from
 `Gordon et al. 2008, ApJ, 682, 336 <https://ui.adsabs.harvard.edu/abs/2008ApJ...682..336G/abstract>`_
 
 .. code-block:: console


### PR DESCRIPTION
Changed wording of the paragraph explaining how to fit an example using `run_pahfit` and the `M101_Nucleus_irs.ipac` example file.