### PR TITLE
fixed typo in article ref in component_models.py

### DIFF
--- a/pahfit/component_models.py
+++ b/pahfit/component_models.py
@@ -35,7 +35,7 @@ class S07_attenuation(Fittable1DModel):
     Smith, Draine, et al. (2007) kvt attenuation model calculation.
     Calculation is for a fully mixed geometrically model.
     Uses an extinction curve based on the silicate profiles from
-    Kemper, Vreind, & Tielens (2004, apJ, 609, 826).
+    Kemper, Vriend, & Tielens (2004, apJ, 609, 826).
     Constructed as a weighted sum of two components: silicate profiles,
     and an exponent 1.7 power-law.
 


### PR DESCRIPTION
Fixed typo:
Kemper, Vriend, & Tielens instead of Kemper, Vreind, & Tielens. 