### PR TITLE
change estimate_start to no_starting_estimate

### DIFF
--- a/pahfit/base.py
+++ b/pahfit/base.py
@@ -112,7 +112,7 @@ class PAHFITBase:
         x_0, x_0_limits, x_0_fixed, fwhms, fwhms_limits, fwhm_fixed}.
     """
 
-    def __init__(self, obs_x, obs_y, estimate_start=False, param_info=None, filename=None, tformat=None):
+    def __init__(self, obs_x, obs_y, no_starting_estimate=False, param_info=None, filename=None, tformat=None):
         """
         Setup a variant based on inputs.  Generates an astropy.modeling
         compound model.
@@ -128,7 +128,7 @@ class PAHFITBase:
         if filename is not None:
             param_info = self.read(filename, tformat=tformat)
 
-        if estimate_start:
+        if not no_starting_estimate:
             # guess values and update starting point (if not set fixed) based on the input spectrum
             param_info = self.estimate_init(obs_x, obs_y, param_info)
 

--- a/pahfit/helpers.py
+++ b/pahfit/helpers.py
@@ -57,7 +57,7 @@ def read_spectrum(specfile, colnames=["wavelength", "flux", "sigma"]):
     return obsdata
 
 
-def initialize_model(packfile, obsdata, estimate_start=False):
+def initialize_model(packfile, obsdata, no_starting_estimate=False):
     """
     Initialize a model based on the packfile
 
@@ -69,8 +69,8 @@ def initialize_model(packfile, obsdata, estimate_start=False):
     obsdata : dict
         observed data where x = wavelength, y = SED, and unc = uncertainties
 
-    estimate_start : boolean
-        estimate the starting parameters based on the observed data
+    no_starting_estimate : boolean
+        Bypass the estimation of the fit starting point based on the input spectrum.
 
     Returns
     -------
@@ -90,7 +90,7 @@ def initialize_model(packfile, obsdata, estimate_start=False):
     pmodel = PAHFITBase(
         obsdata["x"].value,
         obsdata["y"].value,
-        estimate_start=estimate_start,
+        no_starting_estimate=no_starting_estimate,
         filename=packfile,
     )
 

--- a/pahfit/scripts/plot_pahfit.py
+++ b/pahfit/scripts/plot_pahfit.py
@@ -62,7 +62,7 @@ def main():
     obsdata = read_spectrum(args.spectrumfile)
 
     # setup the model
-    pmodel = initialize_model(args.fitfilename, obsdata, estimate_start=False)
+    pmodel = initialize_model(args.fitfilename, obsdata, no_starting_estimate=True)
 
     # plot result
     fontsize = 18

--- a/pahfit/scripts/run_pahfit.py
+++ b/pahfit/scripts/run_pahfit.py
@@ -53,9 +53,9 @@ def initialize_parser():
         help="Save fit results to a file of specified type",
     )
     parser.add_argument(
-        "--estimate_start",
+        "--no_starting_estimate",
         action="store_true",
-        help="Estimate of starting point based on the input spectrum",
+        help="Bypass the estimation of the fit starting point based on the input spectrum",
     )
     parser.add_argument(
         "--scalefac_resid",
@@ -84,7 +84,7 @@ def main():
     obsdata = read_spectrum(args.spectrumfile)
 
     # setup the model
-    pmodel = initialize_model(args.packfile, obsdata, args.estimate_start)
+    pmodel = initialize_model(args.packfile, obsdata, args.no_starting_estimate)
 
     # fit the spectrum
     obsfit = fit_spectrum(obsdata, pmodel, maxiter=args.fit_maxiter)


### PR DESCRIPTION
Changed `no_estimate` argument to `no_starting_estimate`. By default the starting point is estimated unless the no_starting_estimate is provided, except for the `plot_pahfit.py` where `no_starting_estimate` is set True.