### PR TITLE
Estimate feature strengths

### DIFF
--- a/pahfit/base.py
+++ b/pahfit/base.py
@@ -367,7 +367,7 @@ class PAHFITBase:
         ax.xaxis.set_major_formatter(mpl.ticker.ScalarFormatter())
 
     @staticmethod
-    def save(obs_fit, filename, outform, strength_calc=True):
+    def save(obs_fit, filename, outform):
         """
         Save the model parameters to a user defined file format.
 
@@ -380,9 +380,6 @@ class PAHFITBase:
             Currently using the input data file name.
         outform : string
             Sets the output file format (ascii, fits, csv, etc.).
-        strength_calc : bool
-            Imports the feature_strength module
-            to calculate PAH feature and emission line strenghts.
         """
         # setup the tables for the different components
         bb_table = Table(
@@ -474,12 +471,9 @@ class PAHFITBase:
                 )
             elif comp_type == "Drude1D":
 
-                if strength_calc:
-                    strength = pah_feature_strength(component.amplitude.value,
-                                                    component.fwhm.value,
-                                                    component.x_0.value)
-                else:
-                    strength = None
+                strength = pah_feature_strength(component.amplitude.value,
+                                                component.fwhm.value,
+                                                component.x_0.value)
 
                 strength_unc = None
 
@@ -505,12 +499,9 @@ class PAHFITBase:
                 )
             elif comp_type == "Gaussian1D":
 
-                if strength_calc:
-                    strength = line_strength(component.amplitude.value,
-                                             component.mean.value,
-                                             component.stddev.value)
-                else:
-                    strength = None
+                strength = line_strength(component.amplitude.value,
+                                         component.mean.value,
+                                         component.stddev.value)
 
                 strength_unc = None
 

--- a/pahfit/base.py
+++ b/pahfit/base.py
@@ -365,7 +365,8 @@ class PAHFITBase:
         ax.xaxis.set_minor_formatter(mpl.ticker.ScalarFormatter())
         ax.xaxis.set_major_formatter(mpl.ticker.ScalarFormatter())
 
-    def save(self, obs_fit, x, yerr, filename, outform):
+    @staticmethod
+    def save(obs_fit, x, yerr, filename, outform):
         """
         Save the model parameters to a user defined file format.
 

--- a/pahfit/base.py
+++ b/pahfit/base.py
@@ -11,7 +11,7 @@ import numpy as np
 
 import matplotlib as mpl
 
-from pahfit.feature_strengths import feature_strength, line_strength
+from pahfit.feature_strengths import pah_feature_strength, line_strength
 
 __all__ = ["PAHFITBase"]
 
@@ -475,9 +475,9 @@ class PAHFITBase:
             elif comp_type == "Drude1D":
 
                 if strength_calc:
-                    strength = feature_strength(component.amplitude.value,
-                                                component.fwhm.value,
-                                                component.x_0.value)
+                    strength = pah_feature_strength(component.amplitude.value,
+                                                    component.fwhm.value,
+                                                    component.x_0.value)
                 else:
                     strength = None
 

--- a/pahfit/base.py
+++ b/pahfit/base.py
@@ -4,7 +4,6 @@ from pahfit.component_models import BlackBody1D, S07_attenuation
 
 from astropy.table import Table, vstack
 from astropy.modeling.physical_models import Drude1D
-from astropy import constants as const, modeling
 
 from scipy import interpolate
 

--- a/pahfit/feature_strengths.py
+++ b/pahfit/feature_strengths.py
@@ -2,7 +2,7 @@ import numpy as np
 from astropy import constants as const
 
 
-def feature_strength(ampl, fwhm, x_0):
+def pah_feature_strength(ampl, fwhm, x_0):
     """
     Calculate PAH feature strengths.
 
@@ -37,7 +37,7 @@ def line_strength(ampl, mean, stddev):
         Gaussian1D amplitude
     mean : float
         Mean of the Gaussian
-    fwhm : float
+    stddev : float
         Gaussian1D stddev
 
     Returns

--- a/pahfit/feature_strengths.py
+++ b/pahfit/feature_strengths.py
@@ -4,7 +4,7 @@ from astropy import constants as const
 
 def pah_feature_strength(ampl, fwhm, x_0):
     """
-    Calculate PAH feature strengths.
+    Calculate the integrated area of PAH feature profiles.
 
     Parameters
     ----------

--- a/pahfit/feature_strengths.py
+++ b/pahfit/feature_strengths.py
@@ -27,6 +27,7 @@ def pah_feature_strength(ampl, fwhm, x_0):
 
     return strength
 
+
 def line_strength(ampl, mean, stddev):
     """
     Calculate emission line strengths.

--- a/pahfit/feature_strengths.py
+++ b/pahfit/feature_strengths.py
@@ -1,0 +1,54 @@
+import numpy as np
+from astropy import constants as const
+
+
+def feature_strength(ampl, fwhm, x_0):
+    """
+    Calculate PAH feature strengths.
+
+    Parameters
+    ----------
+    ampl : float
+        Drude1D amplitude
+    fwhm : float
+        Drude1D fwhm
+    x_0 : float
+        Drude1D peak position
+
+    Returns
+    -------
+    strength : float
+        PAH feature strength in W/m^2/Hz units.
+
+    """
+
+    # TODO: Use input units to determine conversion and feature strength units.
+    strength = (np.pi * const.c.to('micron/s') / 2) * (ampl * fwhm / x_0**2) * 1e-26
+
+    return strength
+
+def line_strength(ampl, mean, stddev):
+    """
+    Calculate emission line strengths.
+
+    Parameters
+    ----------
+    ampl : float
+        Gaussian1D amplitude
+    mean : float
+        Mean of the Gaussian
+    fwhm : float
+        Gaussian1D stddev
+
+    Returns
+    -------
+    strength : float
+        Emission line strength in W/m^2/Hz units.
+
+    """
+
+    # TODO: Use input units to determine conversion and line strength units.
+    fwhm = 2 * stddev * np.sqrt(2 * np.log(2))
+    strength = ((np.sqrt(np.pi / np.log(2))) * const.c.to('micron/s').value / 2) * (ampl * fwhm / mean**2) * 1e-26
+
+    return strength

--- a/pahfit/scripts/run_pahfit.py
+++ b/pahfit/scripts/run_pahfit.py
@@ -70,6 +70,11 @@ def initialize_parser():
         type=int,
         help="Maximum number of interations for the fitting",
     )
+    parser.add_argument(
+        "--strength_calc",
+        action="store_true",
+        help="Calculate PAH feature and emission line strenghts",
+    )
 
     return parser
 
@@ -91,7 +96,7 @@ def main():
 
     # save fit results to file
     outputname = args.spectrumfile.split(".")[0]
-    pmodel.save(obsfit, obsdata["x"], obsdata["unc"], outputname, args.saveoutput)
+    pmodel.save(obsfit, outputname, args.saveoutput, strength_calc=args.strength_calc)
 
     # plot result
     fontsize = 18

--- a/pahfit/scripts/run_pahfit.py
+++ b/pahfit/scripts/run_pahfit.py
@@ -70,11 +70,6 @@ def initialize_parser():
         type=int,
         help="Maximum number of interations for the fitting",
     )
-    parser.add_argument(
-        "--strength_calc",
-        action="store_true",
-        help="Calculate PAH feature and emission line strenghts",
-    )
 
     return parser
 
@@ -96,7 +91,7 @@ def main():
 
     # save fit results to file
     outputname = args.spectrumfile.split(".")[0]
-    pmodel.save(obsfit, outputname, args.saveoutput, strength_calc=args.strength_calc)
+    pmodel.save(obsfit, outputname, args.saveoutput)
 
     # plot result
     fontsize = 18

--- a/pahfit/scripts/run_pahfit.py
+++ b/pahfit/scripts/run_pahfit.py
@@ -91,7 +91,7 @@ def main():
 
     # save fit results to file
     outputname = args.spectrumfile.split(".")[0]
-    pmodel.save(obsfit, outputname, args.saveoutput)
+    pmodel.save(obsfit, obsdata["x"], obsdata["unc"], outputname, args.saveoutput)
 
     # plot result
     fontsize = 18


### PR DESCRIPTION
This PR should replace #141. 

Differences with #141:
- New separate module `feature_strengths.py` now called to calculate PAH feature and emission line strengths.
- Profile-weighted uncertainties removed, but output table uncertainty entry kept (empty) as placeholder for future implementation.
- New argument in `run_pahfit` (`--strength_calc`) which will enable feature strength calculation when provided.