### PR TITLE
small changes to docs

### DIFF
--- a/docs/file_formats.rst
+++ b/docs/file_formats.rst
@@ -15,18 +15,18 @@ the bounds (i.e., min and max), and if the parameter is fixed or not.
 For the `BlackBody1D` models, the fit parameters are temperature (`temp`)
 and  "intrinsic" or "unattenuated" amplitude (`amp`).
 For the `Drude1D` and `Gaussian1D` models, the fit parameters are
- "intrinsic" or "unattenuated" amplitude (`amp`), center wavelength (`x_0`), and
+"intrinsic" or "unattenuated" amplitude (`amp`), center wavelength (`x_0`), and
 full width at half maximum (`fwhm`).
 For the dust attenuation model (`S07_att`), the fit parameters are
 amplitude (`amp`).
 
-We use the astropy version of `Drude1D
-<https://docs.astropy.org/en/stable/modeling/physical_models.html#drude1d>`
+The astropy version of `Drude1D
+<https://docs.astropy.org/en/stable/modeling/physical_models.html#drude1d>`_
 and `Gaussian1D
-<https://docs.astropy.org/en/stable/api/astropy.modeling.functional_models.Gaussian1D.html#astropy.modeling.functional_models.Gaussian1D>`. See
-:ref:`BlackBody1D <pahfit.component_models.BlackBody1D>` and  
-:ref:`dust attenuation model
-     <pahfit.component_models.S07_attenuation>` for a
+<https://docs.astropy.org/en/stable/api/astropy.modeling.functional_models.Gaussian1D.html#astropy.modeling.functional_models.Gaussian1D>`_
+are used. See
+:ref:`BlackBody1D <BlackBody1D>` and  
+:ref:`dust attenuation model <S07_attenuation>` for a
 description of BlackBody1D and the dust attenuation model.
 
 The model packs are saved as IPAC tables as these provide readable (ASCII)
@@ -36,8 +36,8 @@ See :ref:`example fit output <example_fit_output>` for an example of
 a model pack/output file.
 
 .. note::
-   IDL PAHFIT uses fractional FWHM for the Drude profiles, python
-   PAHFIT uses FWHM for the Drude profiles.
+   IDL PAHFIT uses fractional FWHM as input/output for the Drude profiles, python
+   PAHFIT uses FWHM as input/output for the Drude profiles.
 
 Fit Outputs
 ===========

--- a/docs/file_formats.rst
+++ b/docs/file_formats.rst
@@ -24,9 +24,7 @@ The astropy version of `Drude1D
 <https://docs.astropy.org/en/stable/modeling/physical_models.html#drude1d>`_
 and `Gaussian1D
 <https://docs.astropy.org/en/stable/api/astropy.modeling.functional_models.Gaussian1D.html#astropy.modeling.functional_models.Gaussian1D>`_
-are used. See
-:ref:`BlackBody1D <BlackBody1D>` and  
-:ref:`dust attenuation model <S07_attenuation>` for a
+are used. See :ref:`reference API <reference_API>` for a
 description of BlackBody1D and the dust attenuation model.
 
 The model packs are saved as IPAC tables as these provide readable (ASCII)

--- a/docs/file_formats.rst
+++ b/docs/file_formats.rst
@@ -13,18 +13,31 @@ and multiple columns for the fit parameters.
 For each fit parameter, the columns are for the actual value,
 the bounds (i.e., min and max), and if the parameter is fixed or not.
 For the `BlackBody1D` models, the fit parameters are temperature (`temp`)
-and amplitude (`amp`).
+and  "intrinsic" or "unattenuated" amplitude (`amp`).
 For the `Drude1D` and `Gaussian1D` models, the fit parameters are
-amplitude (`amp`), center wavelength (`x_0`), and
+ "intrinsic" or "unattenuated" amplitude (`amp`), center wavelength (`x_0`), and
 full width at half maximum (`fwhm`).
 For the dust attenuation model (`S07_att`), the fit parameters are
 amplitude (`amp`).
+
+We use the astropy version of `Drude1D
+<https://docs.astropy.org/en/stable/modeling/physical_models.html#drude1d>`
+and `Gaussian1D
+<https://docs.astropy.org/en/stable/api/astropy.modeling.functional_models.Gaussian1D.html#astropy.modeling.functional_models.Gaussian1D>`. See
+:ref:`BlackBody1D <pahfit.component_models.BlackBody1D>` and  
+:ref:`dust attenuation model
+     <pahfit.component_models.S07_attenuation>` for a
+description of BlackBody1D and the dust attenuation model.
 
 The model packs are saved as IPAC tables as these provide readable (ASCII)
 files that include unit information.
 
 See :ref:`example fit output <example_fit_output>` for an example of
 a model pack/output file.
+
+.. note::
+   IDL PAHFIT uses fractional FWHM for the Drude profiles, python
+   PAHFIT uses FWHM for the Drude profiles.
 
 Fit Outputs
 ===========

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -85,6 +85,8 @@ For the complete list of contributors please see the `pahfit
 contributors page on Github
 <https://github.com/karllark/pahfit/graphs/contributors>`_.
 
+.. _reference_API:
+
 Reference API
 =============
 


### PR DESCRIPTION
Added "intrinsic" or "unattenuated" to amplitudes of BB and features (issue 130)

Added comment that we use astropy Gaussian1D and Drude1D + link (issue 122)

Added comment stating IDL PAHFIT uses fractional FWHM while here we use FWHM
for Drude profiles (issue 152). We can update this if we decide to change it.