### PR TITLE
updating test versions

### DIFF
--- a/.github/workflows/tex-tests.yml
+++ b/.github/workflows/tex-tests.yml
@@ -27,7 +27,7 @@ jobs:
         # For example -- os: [ubuntu-latest, macos-latest, windows-latest]
         os: [ubuntu-latest, macos-latest, windows-latest]
 
-        # Test python 3.6, 3.7, and 3.8 by default.
+        # Test python 3.8, 3.9, and 3.10 by default.
         python-ver: [8, 9, 10]
 
         # Specify which tox environments to test in this list.

--- a/.github/workflows/tex-tests.yml
+++ b/.github/workflows/tex-tests.yml
@@ -28,7 +28,7 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
 
         # Test python 3.6, 3.7, and 3.8 by default.
-        python-ver: [6, 7, 8]
+        python-ver: [8, 9, 10]
 
         # Specify which tox environments to test in this list.
         # tox-env: [cov, alldeps, devdeps, astropylts]
@@ -56,14 +56,14 @@ jobs:
     - name: Set up python for astropy, numpy dev test
       uses: actions/setup-python@v1
       with:
-        python-version: 3.8
+        python-version: 3.10
     - name: Install base dependencies
       run: |
         python -m pip install --upgrade pip
         python -m pip install tox
     - name: Test with tox
       run: |
-        tox -e py38-devdeps
+        tox -e py310-devdeps
 
   # LTS version test
   lts_test:
@@ -74,14 +74,14 @@ jobs:
     - name: Set up python for astropy lts test
       uses: actions/setup-python@v1
       with:
-        python-version: 3.8
+        python-version: 3.10
     - name: Install base dependencies
       run: |
         python -m pip install --upgrade pip
         python -m pip install tox
     - name: Test with tox
       run: |
-        tox -e py38-astropylts
+        tox -e py310-astropylts
 
   # Coverage test
   cov_test:
@@ -92,14 +92,14 @@ jobs:
     - name: Set up python for coverage test
       uses: actions/setup-python@v1
       with:
-        python-version: 3.8
+        python-version: 3.10
     - name: Install base dependencies
       run: |
         python -m pip install --upgrade pip
         python -m pip install tox
     - name: Test with tox
       run: |
-        tox -e py38-cov
+        tox -e py310-cov
     - name: Upload coverage to codecov
       uses: codecov/codecov-action@v1
       with:
@@ -122,7 +122,7 @@ jobs:
     - name: Set up Python to build docs with sphinx
       uses: actions/setup-python@v1
       with:
-        python-version: 3.8
+        python-version: 3.10
     - name: Install base dependencies
       run: |
         python -m pip install --upgrade pip
@@ -141,7 +141,7 @@ jobs:
     - name: Set up Python to build docs with sphinx
       uses: actions/setup-python@v1
       with:
-        python-version: 3.8
+        python-version: 3.10
     - name: Install base dependencies
       run: |
         python -m pip install --upgrade pip
@@ -160,7 +160,7 @@ jobs:
     - name: Python codestyle check
       uses: actions/setup-python@v1
       with:
-        python-version: 3.8
+        python-version: 3.10
     - name: Install base dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/tex-tests.yml
+++ b/.github/workflows/tex-tests.yml
@@ -56,7 +56,7 @@ jobs:
     - name: Set up python for astropy, numpy dev test
       uses: actions/setup-python@v1
       with:
-        python-version: 3.10
+        python-version: '3.10'
     - name: Install base dependencies
       run: |
         python -m pip install --upgrade pip
@@ -74,7 +74,7 @@ jobs:
     - name: Set up python for astropy lts test
       uses: actions/setup-python@v1
       with:
-        python-version: 3.10
+        python-version: '3.10'
     - name: Install base dependencies
       run: |
         python -m pip install --upgrade pip
@@ -92,7 +92,7 @@ jobs:
     - name: Set up python for coverage test
       uses: actions/setup-python@v1
       with:
-        python-version: 3.10
+        python-version: '3.10'
     - name: Install base dependencies
       run: |
         python -m pip install --upgrade pip
@@ -122,7 +122,7 @@ jobs:
     - name: Set up Python to build docs with sphinx
       uses: actions/setup-python@v1
       with:
-        python-version: 3.10
+        python-version: '3.10'
     - name: Install base dependencies
       run: |
         python -m pip install --upgrade pip
@@ -141,7 +141,7 @@ jobs:
     - name: Set up Python to build docs with sphinx
       uses: actions/setup-python@v1
       with:
-        python-version: 3.10
+        python-version: '3.10'
     - name: Install base dependencies
       run: |
         python -m pip install --upgrade pip
@@ -160,7 +160,7 @@ jobs:
     - name: Python codestyle check
       uses: actions/setup-python@v1
       with:
-        python-version: 3.10
+        python-version: '3.10'
     - name: Install base dependencies
       run: |
         python -m pip install --upgrade pip

--- a/tox.ini
+++ b/tox.ini
@@ -44,7 +44,7 @@ description =
     numpy121: with numpy 1.21.*
     astropy40: with astropy 4.0.*
     astropy50: with astropy 5.0.*
-    astropylts: with the latest astropy LTS
+    astropylts: with the latest astropy LTS (currently v5.0)
 
 # The following provides some specific pinnings for key packages
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist =
-    py{36,37,38}-test{,-alldeps,-devdeps}{,-cov}
-    py{36,37,38}-test-numpy{116,117,118}
-    py{36,37,38}-test-astropy{30,40}
+    py{38,39,310}-test{,-alldeps,-devdeps}{,-cov}
+    py{38,39,310}-test-numpy{118,119,120,121}
+    py{38,39,310}-test-astropy{40,50}
     build_docs
     linkcheck
     codestyle
@@ -38,23 +38,25 @@ description =
     devdeps: with the latest developer version of key dependencies
     oldestdeps: with the oldest supported version of key dependencies
     cov: and test coverage
-    numpy116: with numpy 1.16.*
-    numpy117: with numpy 1.17.*
     numpy118: with numpy 1.18.*
-    astropy30: with astropy 3.0.*
+    numpy119: with numpy 1.19.*
+    numpy120: with numpy 1.20.*
+    numpy121: with numpy 1.21.*
     astropy40: with astropy 4.0.*
+    astropy50: with astropy 5.0.*
     astropylts: with the latest astropy LTS
 
 # The following provides some specific pinnings for key packages
 deps =
 
-    numpy116: numpy==1.16.*
-    numpy117: numpy==1.17.*
     numpy118: numpy==1.18.*
+    numpy119: numpy==1.19.*
+    numpy120: numpy==1.20.*
+    numpy121: numpy==1.21.*
 
-    astropy30: astropy==3.0.*
     astropy40: astropy==4.0.*
-    astropylts: astropy==4.0.*
+    astropy50: astropy==5.0.*
+    astropylts: astropy==5.0.*
 
     devdeps: :NIGHTLY:numpy
     devdeps: git+https://github.com/astropy/astropy.git#egg=astropy


### PR DESCRIPTION
python 3.6 no longer allowed.  python 3.7 old as well.  Moving tests to newer version of python, numpy, and astropy.  Based on current astropy tox.ini.