### PR TITLE
Simple FWHM Fix

### DIFF
--- a/pahfit/base.py
+++ b/pahfit/base.py
@@ -134,6 +134,9 @@ class PAHFITBase:
             # guess values and update starting point (if not set fixed) based on the input spectrum
             param_info = self.estimate_init(obs_x, obs_y, param_info)
 
+        if not param_info:
+            raise ValueError("No parameter information set.")
+        
         self.param_info = param_info
 
         bb_info = param_info[0]

--- a/pahfit/base.py
+++ b/pahfit/base.py
@@ -209,8 +209,8 @@ class PAHFITBase:
                         "amplitude": h2_features["amps_limits"][k],
                         "mean": h2_features["x_0_limits"][k],
                         "stddev": (
-                            h2_features["fwhms_limits"][k][0] / 2.355,
-                            h2_features["fwhms_limits"][k][1] / 2.355,
+                            h2_features["fwhms"][k]*0.9 / 2.355,
+                            h2_features["fwhms"][k]*1.1 / 2.355,
                         ),
                     },
                     fixed={
@@ -232,8 +232,8 @@ class PAHFITBase:
                         "amplitude": ion_features["amps_limits"][k],
                         "mean": ion_features["x_0_limits"][k],
                         "stddev": (
-                            ion_features["fwhms_limits"][k][0] / 2.355,
-                            ion_features["fwhms_limits"][k][1] / 2.355,
+                            ion_features["fwhms"][k] * 0.9 / 2.355,
+                            ion_features["fwhms"][k] * 1.1 / 2.355,
                         ),
                     },
                     fixed={


### PR DESCRIPTION
This is a simple fix for the overly generous 2x FWHM (see #174), which led to spurious fits.  This simply hard-codes the 10% for now.  In the near term, we plan to implement a new Instrument Pack/Science Pack with generator, making this code irrelevant.