### PR TITLE
Multi + glob-style instrument specification for stitched spectra fitting

### DIFF
--- a/pahfit/errors.py
+++ b/pahfit/errors.py
@@ -4,3 +4,7 @@ class PAHFITFeatureError(Exception):
 
 class PAHFITPackError(Exception):
     pass
+
+
+class PAHFITWarning(Warning):
+    pass

--- a/pahfit/packs/instrument.py
+++ b/pahfit/packs/instrument.py
@@ -9,8 +9,10 @@ heirarchical names, e.g. 'iso.sws.speed0.3a'.  For the full list of
 supported telescopes, instruments, and instrument modes, see TBD.
 """
 
-import glob
 import os
+from pathlib import Path
+import glob
+import numpy as np
 from numpy.polynomial import Polynomial
 from astropy.io.misc import yaml
 from pkg_resources import resource_filename
@@ -21,6 +23,7 @@ packs = {}
 
 def read_instrument_packs():
     """Read all instrument packs into the 'packs' variable."""
+    global packs
     for pack in glob.glob(resource_filename("pahfit", "packs/instrument/*.yaml")):
         try:
             with open(pack) as fd:
@@ -31,61 +34,120 @@ def read_instrument_packs():
         else:
             telescope = os.path.basename(pack).rstrip('.yaml')
             packs[telescope] = p
+    packs = dict(_ins_items('', packs))  # Flatten list
 
 
-def pack_element(segment):
-    """Return the pack element for the given segment name.
+def pack_element(segments):
+    """Return the pack element(s) for the given segment name(s).
 
     Arguments:
     ----------
-      segment: The fully qualified segment name, as a string.
+
+      segments: The fully qualified segment name, as a string. Can be a
+        scalar or a list, for returning more than one pack.  Each
+        segment name can optionally contain glob characters recognized
+        by Pathlib.Path.match (e.g. `*' or [123]).  This can be used
+        to match multiple segments.
 
     Returns:
     --------
 
-    The dictionary structure including the keys 'range' and
-    'coefficients' of the named segment.
+    A list of dictionary structures including the keys 'range' and
+    'coefficients' of the named segment(s).
 
     Raises:
     -------
 
-    PAHFITPackError: If the named segment cannot be identified.
+    PAHFITPackError: If none of the named segments can be identified.
+
     """
     global packs
-    d = packs
-    for key in segment.split('.'):
-        d = d.get(key)
-        if d is None:
-            raise PAHFITPackError(f"Could not locate instrument segment {key} of {segment}")
-    if d.get('polynomial') is None:
-        try:
-            d['polynomial'] = Polynomial(d['coefficients'])
-        except KeyError:
-            raise PAHFITPackError(f"Incomplete segment name {segment}")
+    ret = []
 
-    return d
+    if not isinstance(segments, (tuple, list)):
+        segments = (segments,)
+
+    for segment in segments:
+        sm = [p for p in packs.keys() if Path(p).match(segment)]
+        if not sm:
+            raise PAHFITPackError(f"Could not locate instrument segment {segment}")
+        for s in sm:
+            if packs[s].get('polynomial') is None:
+                try:
+                    packs[s]['polynomial'] = Polynomial(packs[s]['coefficients'])
+                except KeyError:
+                    raise PAHFITPackError(f"Invalid instrument pack {s}")
+            ret.append(packs[s])
+
+    return ret
 
 
-def _ins_name(path, tree):
-    """Generator for instrument names."""
+def _ins_items(path, tree):
+    """Generator for traversing packs."""
     if isinstance(tree, dict) and not tree.get("range"):
         _dot = "." if len(path) > 0 else ""
         for key, sub in tree.items():
-            yield from _ins_name(f"{path}{_dot}{key}", sub)
+            yield from _ins_items(f"{path}{_dot}{key}", sub)
     else:
-        yield path
+        yield path, tree
 
 
-def instruments():
-    """Returns fully qualified set of supported instrument names."""
+def instruments(match=None):
+    """Returns fully qualified set of supported instrument names.
+
+    Arguments:
+    ----------
+
+      match (Optional): A string or iterable of strings to match
+       against the full instrument list. If provide, only the list of
+       matching instruments is returned.  Useful for checking a
+       glob-style instrument name results in the desired instrument
+       set.
+
+    Returns:
+    --------
+
+      The list of matching instruments, if any.
+
+    """
     if len(packs) == 0:
         read_instrument_packs()
-    return _ins_name('', packs)
+    ins = packs.keys()
+    ret = []
+    if match:
+        if not isinstance(match, (tuple, list)):
+            match = (match,)
+        for m in match:
+            ret.extend([p for p in ins if Path(p).match(m)])
+        return ret
+    else:
+        return list(ins)
 
 
 def resolution(segment, wave_micron):
-    p = pack_element(segment)['polynomial']
-    return p(wave_micron)
+    _packs = pack_element(segment)
+    npk = len(_packs)
+    if npk == 1:
+        return _packs[0]['polynomial'](wave_micron)
+
+    wave_micron = np.atleast_1d(wave_micron)
+
+    res = np.ma.empty((npk,) + wave_micron.shape)
+    for i, p in enumerate(_packs):
+        inside = (wave_micron >= p['range'][0]) & (wave_micron <= p['range'][1])
+        res[i, inside] = p['polynomial'](wave_micron[inside])
+        res[i, ~inside] = np.ma.masked
+
+    out = np.ma.empty_like(wave_micron, shape=wave_micron.shape + (3,))
+    out[:] = np.ma.masked  # mask all by default
+    out[..., 0] = np.mean(res, 0)
+
+    multi = np.count_nonzero(res, 0) > 1  # waves matching more than one segment
+    if np.count_nonzero(multi) > 0:
+        out[multi, 1] = np.min(res[:, multi], 0)
+        out[multi, 2] = np.max(res[:, multi], 0)
+
+    return out
 
 
 def fwhm(segment, wave_micron):
@@ -96,20 +158,38 @@ def fwhm(segment, wave_micron):
       segment: The fully qualified segment name, as a string.
 
       wave_micron: The observed-frame (instrument-relative) wavelength
-      in microns, as a scalar or numpy array.
+        in microns, as a scalar or numpy array.
 
     Returns:
     --------
 
-    The full-width at half maximum of an unresolved line spread
-    function, at the relevant wavelength(s).
+    The full-width at half maxima of unresolved line spread functions
+    at the relevant wavelength(s), either as a scalar (if only one
+    segment applied) or as a 3 element tuple of:
+
+      (value, low bound, high bound)
+
     """
-    return wave_micron / resolution(segment, wave_micron)
+
+    r = resolution(segment, wave_micron)
+    if np.ma.isMaskedArray(r):
+        ret = np.expand_dims(wave_micron, -1) / r
+        return ret[..., (0, 2, 1)]  # swap lower with upper (inverse!)
+    else:
+        return wave_micron / r
 
 
 def wave_range(segment):
-    """Return the segment wavelength range (a two element list) in microns."""
-    return pack_element(segment)['range']
+    """Return the segment wavelength range(s) in microns.  If more
+    than one segment is specified (either directly, or via glob-style
+    matching), the return value is a list of two element lists [min,
+    max].
+    """
+    ret = [x['range'] for x in pack_element(segment)]
+    if len(ret) == 1:
+        return ret[0]
+    else:
+        return ret
 
 
 read_instrument_packs()

--- a/pahfit/packs/instrument/spitzer.yaml
+++ b/pahfit/packs/instrument/spitzer.yaml
@@ -32,10 +32,10 @@ irs:
             coefficients: [0.0, 8.2667]
     ll:
         '1':
-            range: [19.4, 21.65]
+            range: [20.5, 38.5]
             coefficients: [0.0, 2.9524]
         '2':
-            range: [14.2, 21.1]
+            range: [14.5, 21.1]
             coefficients: [0.0, 5.9048]
         '3':
             range: [19.4, 21.65]


### PR DESCRIPTION
This supports fitting stitched spectra by allowing the user to specify an iterable of instruments instead of just a single value per input spectrum:

``` python
ins=("jwst.miri.mrs.ch1.A","jwst.miri.mrs.ch1.B")
```

and/or glob-style match strings:

``` python
ins="jwst.miri.mrs.ch*.[AB]"
```

It works by identifying all overlapping instrument segments at the given wavelengths, computing all relevant resolutions, and using the _average_ value with lower and upper bounds set to the min and max predicted resolution.  Lines which intersect only one segment have masked bounds (i.e., are fixed).

Note that, if multiple segments are provided or matched:

1. the return value of `wave_ranges()` can be a list of (2-element) lists.
2. `fwhm()` and `resolution()` return `(n, 3)` _masked_ arrays (given `n` input wavelengths).  The additional 2 values specify lower and upper bounds.

Also note that `instruments()` now takes an optional `match` argument, which can be used to test a given match:

``` python
In [399]: instruments(('jwst.nirspec.*.medium','jwst.miri.mrs.ch*.[AB]'))
Out[399]: 
['jwst.nirspec.g140.medium',
 'jwst.nirspec.g235.medium',
 'jwst.nirspec.g395.medium',
 'jwst.miri.mrs.ch1.A',
 'jwst.miri.mrs.ch1.B',
 'jwst.miri.mrs.ch2.A',
 'jwst.miri.mrs.ch2.B',
 'jwst.miri.mrs.ch3.A',
 'jwst.miri.mrs.ch3.B',
 'jwst.miri.mrs.ch4.A',
 'jwst.miri.mrs.ch4.B']
```