### PR TITLE
read_spectrum as a wrapper around Spectrum1D.read

### DIFF
--- a/pahfit/helpers.py
+++ b/pahfit/helpers.py
@@ -81,7 +81,7 @@ def read_spectrum(specfile, format=None):
     if format is None:
         suffix = specfile.split(".")[-1].lower()
         if suffix == "ecsv":
-            tformat = "ascii.ecsv"
+            tformat = "ECSV"
         elif suffix == "ipac":
             tformat = "IPAC"
     else:

--- a/pahfit/tests/test_included_spectra.py
+++ b/pahfit/tests/test_included_spectra.py
@@ -1,0 +1,19 @@
+from pahfit.helpers import read_spectrum
+
+
+def test_read_spectrum():
+    """Tests to make sure that ALL the included files can be read in
+    out of the box. Later, we could add a test that makes sure that all
+    included data at least don't make PAHFIT crash (e.g. issue 239
+    https://github.com/PAHFIT/pahfit/issues/239)
+    """
+    files = [
+        "1C_snr_gt20.ecsv",
+        "ISO_SWS/Orion_Brgamma_ISO-SWS_merged.ipac",
+        "Lai2020_1C_akari_spitzer.ecsv",
+        "M101_Nucleus_irs.ipac",
+        "MIRI_MRS/VV114_MIRI_ch1_LONG_s1d.fits",
+        "orion_bar_SWS_with7023shape.ipac",
+    ]
+    for f in files:
+        _ = read_spectrum(f)

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ docs =
     sphinx-astropy
 
 [options.package_data]
-pahfit = data/*, packs/science/*, packs/instrument/*
+pahfit = data/*, data/ISO_SWS/*, data/MIRI_MRS/*, packs/science/*, packs/instrument/*
 
 [tool:pytest]
 testpaths = "pahfit" "docs"


### PR DESCRIPTION
I found that the specutils reader doesn't care if the columns are named 'sigma' or 'stddev'. So just by changing the reader to Spectrum1D, we can now read in all our included spectra.

I also added a test for this read-in step. It was already useful to iron out some bugs and convince myself that this will work for everything we need. Should be useful in the future too, when new example spectra get added.