### PR TITLE
Tabulate model spectrum

### DIFF
--- a/pahfit/base.py
+++ b/pahfit/base.py
@@ -15,6 +15,7 @@ import numpy as np
 import matplotlib as mpl
 
 from pahfit.instrument import within_segment, fwhm
+from pahfit.errors import PAHFITModelError
 
 __all__ = ["PAHFITBase"]
 
@@ -243,7 +244,7 @@ class PAHFITBase:
 
         # add additional att components to the model if necessary
         if not model:
-            raise ValueError("No model components found")
+            raise PAHFITModelError("No model components found")
 
         if abs_info is not None:
             for k in range(len(abs_info["names"])):

--- a/pahfit/model.py
+++ b/pahfit/model.py
@@ -126,8 +126,7 @@ class Model:
         if fn.split(".")[-1] != "ecsv":
             raise NotImplementedError("Only ascii.ecsv is supported for now")
 
-        self.features.meta['use_instrument_fwhm'] = self.use_instrument_fwhm
-        self.features.meta['fit_info'] = self.fit_info
+        self.features.meta["use_instrument_fwhm"] = self.use_instrument_fwhm
 
         self.features.write(fn, format="ascii.ecsv", **write_kwargs)
 
@@ -172,6 +171,7 @@ class Model:
         Nothing, but internal feature table is updated.
 
         """
+        # parse spectral data
         self.features.meta["unit"] = spec.flux.unit
         inst, z = self._parse_instrument_and_redshift(spec, redshift)
         _, _, _, xz, yz, _ = self._convert_spec_data(spec, z)
@@ -188,9 +188,10 @@ class Model:
     @staticmethod
     def _convert_spec_data(spec, z):
         """
-        Turn astropy quantities into fittable numbers.
+        Turn astropy quantities stored in Spectrum1D into fittable
+        numbers.
 
-        Also corrects for redshift
+        Also corrects for redshift.
 
         Returns
         -------
@@ -218,7 +219,8 @@ class Model:
     ):
         """Fit the observed data.
 
-        The model setup is based on the features table and instrument specification.
+        The model setup is based on the features table and instrument
+        specification.
 
         The last fit results can accessed through the variable
         model.astropy_result. The results are also stored back to the
@@ -376,12 +378,11 @@ class Model:
         flux_unit : Unit
             Specify or override the flux unit. Needs to be compatible
             with MJy or MJy / sr.
-
-        feature_mask : row mask
+        feature_mask : array of bool of length len(features)
             Mask used to select specific rows of the feature table. In
             most use cases, this mask can be made by applying a boolean
             operation to a column of self.features, e.g.
-            model.features['wavelength']>8.5
+            model.features['wavelength'] > 8.5
 
         Returns
         -------

--- a/pahfit/model.py
+++ b/pahfit/model.py
@@ -60,6 +60,12 @@ class Model:
             )
 
         self.features = features
+
+        # If features table does not originate from a previous fit, and
+        # hence has no unit yet, we initialize it as None.
+        if "unit" not in self.features.meta:
+            self.features.meta["unit"] = None
+
         # if set to False, use set fwhm for lines to value in features
         # table at model construction
         self.use_instrument_fwhm = True
@@ -165,6 +171,7 @@ class Model:
         Nothing, but internal feature table is updated.
 
         """
+        self.features.meta["unit"] = spec.flux.unit
         inst, z = self._parse_instrument_and_redshift(spec, redshift)
         _, _, _, xz, yz, _ = self._convert_spec_data(spec, z)
 
@@ -244,6 +251,7 @@ class Model:
 
         """
         # parse spectral data
+        self.features.meta["unit"] = spec.flux.unit
         inst, z = self._parse_instrument_and_redshift(spec, redshift)
         x, _, _, xz, yz, uncz = self._convert_spec_data(spec, z)
 

--- a/pahfit/model.py
+++ b/pahfit/model.py
@@ -3,7 +3,7 @@ from astropy import units as u
 import copy
 from astropy.modeling.fitting import LevMarLSQFitter
 from matplotlib import pyplot as plt
-from astropy.table import Table
+import numpy as np
 
 from pahfit.helpers import find_packfile
 from pahfit.features import Features
@@ -325,59 +325,27 @@ class Model:
         # A standard deepcopy works fine!
         return copy.deepcopy(self)
 
-    def flux_function(self, instrumentname, redshift=0, kind=None):
-        """Create function representing flux as function of wavelength.
-
-        Parameters
-        ----------
-        instrumentname : str or list of str
-            Qualified instrument name, see instrument.py. This
-            determines the wavelength range of features to be included.
-            The FWHM of the unresolved lines will be determined by the
-            value in the features table, instead of the instrument. This
-            allows us to visualize the fitted line widths in the
-            spectral overlap regions.
-
-        redshift: float
-            The redshift also affects the wavelength range of features
-            to be included.
-
-        kind: str
-            Filter the features by kind, before constructing the flux
-            function. Consult the Model.features['kind'] column to see
-            the options. Includes all features when set to None.
-
-        Returns
-        -------
-        flux_function : callable
-            This function is constructed according to the contents of
-            the features table. It can be evaluated at a wavelength (or
-            a grid of wavelengths) in micron, using the call operator,
-            e.g. flux_function(wav).
-
-        """
-        filtered_features = self.features.copy()
-        if kind is not None:
-            filtered_features = filtered_features[filtered_features["kind"] == kind]
-
-        alt_model = Model(filtered_features)
-        flux_function = alt_model._construct_astropy_model(
-            instrumentname, redshift, use_instrument_fwhm=False
-        )
-        return flux_function
-
-    def save_model_flux(
-        self, fn, wavelengths, instrumentname, redshift=0, kind=None, flux_unit=None
+    def tabulate(
+        self,
+        instrumentname,
+        redshift=0,
+        wavelengths=None,
+        spec=None,
+        flux_unit=None,
+        feature_mask=None,
     ):
-        """Save tabulated flux model to a file.
+        """Tabulate model flux on a wavelength grid, and export as Spectrum1D
 
         Parameters
         ----------
-        fn : str
-            File name. Suggested type is ecsv.
-
         wavelengths : array
-            Wavelengths in micron at which to evaluate the function
+            Wavelengths in micron at which to evaluate the function.
+            Will be multiplied with 1/(1+z) if redshift z is given.
+
+        spec : Spectrum1D
+            Alternative to wavelengths, a reference spectrum can be
+            given. Its wavelengths will be used to tabulate the flux,
+            and the returned Spectrum1D object will have the same units.
 
         instrumentname : str or list of str
             Qualified instrument name, see instrument.py. This
@@ -397,31 +365,60 @@ class Model:
             the options. Includes all features when set to None.
 
         flux_unit : Unit
-            The unit of the flux to save in the output file. Unitless by
-            default.
+            Specify or override the flux unit. Needs to be compatible
+            with MJy or MJy / sr.
 
-        Output
-        ------
-        Writes astropy table to file, containing the model spectrum at
-        rest-frame wavelengths.
+        feature_mask : row mask
+            Mask used to select specific rows of the feature table. In
+            most use cases, this mask can be made by applying a boolean
+            operation to self.features, e.g.
+            model.features['wavelength']>8.5
 
+        Returns
+        -------
+        model_spectrum : Spectrum1D
+            The flux model, evaluated at the given wavelengths, packaged
+            as a Spectrum1D object.
         """
-        # evaluate at rest wavelength
-        oneplusz = 1 + redshift
-        wrest = wavelengths / oneplusz
-        flux_values = self.flux_function(instrumentname, redshift, kind)
+        # apply feature mask, make sub model, and set up functional
+        if feature_mask is not None:
+            features_copy = self.features.copy()
+            features_to_use = features_copy[feature_mask]
+        else:
+            features_to_use = self.features
+        alt_model = Model(features_to_use)
+        flux_function = alt_model._construct_astropy_model(
+            instrumentname, redshift, use_instrument_fwhm=False
+        )
+
+        # decide which wavelength grid to use
+        if wavelengths is not None:
+            wav = wavelengths
+        elif spec is not None:
+            wav = spec.spectral_axis.to(u.micron).value
+        else:
+            ranges = instrument.wave_range(instrumentname)
+            wmin = min(r[0] for r in ranges)
+            wmax = max(r[1] for r in ranges)
+            wfwhm = instrument.fwhm(instrumentname, wmin, as_bounded=True)[0, 0]
+            wav = np.arange(wmin, wmax, wfwhm / 2)
+
+        # shift the "observed wavelength grid" to "physical wavelength grid"
+        wav /= 1 + redshift
+        flux_values = flux_function(wav)
 
         # Can only set unit unambiguously when we properly deal with the
-        # flux units of the input. (what about the cases where we don't
-        # have an input spectrum anyway?)
+        # flux units of the input. When no reference spectrum is given,
+        # we need to guess a unit.
         if flux_unit is not None:
-            flux_values *= flux_unit
+            flux_unit_to_use = flux_unit
+        elif spec is not None:
+            flux_unit_to_use = spec.flux.unit
+        else:
+            flux_unit_to_use = u.dimensionless_unscaled
 
-        t = Table()
-        t.add_column(wrest * u.micron, name="WAVELENGTH")
-        t.add_column(flux_values, name="FLUX")
-        t.write(
-            fn, format="ascii.ecsv" if fn.endswith(".ecsv") else None, overwrite=True
+        return Spectrum1D(
+            spectral_axis=wav * u.micron, flux=flux_values * flux_unit_to_use
         )
 
     def _kludge_param_info(self, instrumentname, redshift, use_instrument_fwhm=True):

--- a/pahfit/model.py
+++ b/pahfit/model.py
@@ -344,9 +344,10 @@ class Model:
         Parameters
         ----------
         wavelengths : Spectrum1D or array-like
-            Wavelengths in micron at which to evaluate the function.
-            Will be multiplied with 1/(1+z) if redshift z is given.
-            If a Spectrum1D is given, wavelengths.spectral_axis will be
+            Wavelengths in micron in the observed frame. Will be
+            multiplied with 1/(1+z) if redshift z is given, so that the
+            model is evaluated in the rest frame as intended. If a
+            Spectrum1D is given, wavelengths.spectral_axis will be
             converted to micron and then used as wavelengths.
 
         instrumentname : str or list of str

--- a/pahfit/model.py
+++ b/pahfit/model.py
@@ -126,6 +126,9 @@ class Model:
         if fn.split(".")[-1] != "ecsv":
             raise NotImplementedError("Only ascii.ecsv is supported for now")
 
+        self.features.meta['use_instrument_fwhm'] = self.use_instrument_fwhm
+        self.features.meta['fit_info'] = self.fit_info
+
         self.features.write(fn, format="ascii.ecsv", **write_kwargs)
 
     def _status_message(self):
@@ -172,6 +175,10 @@ class Model:
         self.features.meta["unit"] = spec.flux.unit
         inst, z = self._parse_instrument_and_redshift(spec, redshift)
         _, _, _, xz, yz, _ = self._convert_spec_data(spec, z)
+
+        # save these as part of the model (will be written to disk too)
+        self.features.meta["redshift"] = inst
+        self.features.meta["instrument"] = z
 
         # remake param_info to make sure we have any feature updates from the user
         param_info = self._kludge_param_info(inst, z)
@@ -252,6 +259,10 @@ class Model:
         self.features.meta["unit"] = spec.flux.unit
         inst, z = self._parse_instrument_and_redshift(spec, redshift)
         x, _, _, xz, yz, uncz = self._convert_spec_data(spec, z)
+
+        # save these as part of the model (will be written to disk too)
+        self.features.meta["redshift"] = inst
+        self.features.meta["instrument"] = z
 
         # check if observed spectrum is compatible with instrument model
         instrument.check_range([min(x), max(x)], inst)

--- a/pahfit/model.py
+++ b/pahfit/model.py
@@ -349,10 +349,12 @@ class Model:
         instrumentname,
         redshift=0,
         wavelengths=None,
-        flux_unit=None,
         feature_mask=None,
     ):
         """Tabulate model flux on a wavelength grid, and export as Spectrum1D
+
+        The flux unit will be the same as the last fitted spectrum, or
+        dimensionless if the model is tabulated before being fit.
 
         Parameters
         ----------
@@ -375,9 +377,6 @@ class Model:
             The redshift is needed to evaluate the flux model at the
             right rest wavelengths.
 
-        flux_unit : Unit
-            Specify or override the flux unit. Needs to be compatible
-            with MJy or MJy / sr.
         feature_mask : array of bool of length len(features)
             Mask used to select specific rows of the feature table. In
             most use cases, this mask can be made by applying a boolean
@@ -424,15 +423,6 @@ class Model:
             flux_quantity = flux_values * u.dimensionless_unscaled
         else:
             flux_quantity = flux_values * self.features.meta["unit"]
-
-        # apply unit override if requested
-        if flux_unit is not None:
-            # if dimensionless, set unit
-            if flux_quantity.unit == u.dimensionless_unscaled:
-                flux_quantity *= flux_unit
-            # if already has unit, convert quantity
-            else:
-                flux_quantity = flux_quantity.to(flux_unit)
 
         return Spectrum1D(spectral_axis=wav * u.micron, flux=flux_quantity)
 

--- a/pahfit/model.py
+++ b/pahfit/model.py
@@ -53,11 +53,6 @@ class Model:
             Features table.
 
         """
-        if len(features) < 2:
-            raise PAHFITModelError(
-                "Fewer than 2 features! Single component models are no allowed!"
-            )
-
         self.features = features
 
         # If features table does not originate from a previous fit, and
@@ -510,6 +505,13 @@ class Model:
         necessary.
 
         """
+        if len(self.features) < 2:
+            # Plotting and tabulating works fine, but the code below
+            # will not work with only one component. This can be
+            # addressed later, when the internal API is made agnostic of
+            # the fitting backend (astropy vs our own).
+            raise PAHFITModelError("Fit with fewr than 2 components not allowed!")
+
         # Some translation rules between astropy model components and
         # feature table names and values.
 

--- a/pahfit/model.py
+++ b/pahfit/model.py
@@ -518,7 +518,7 @@ class Model:
             # will not work with only one component. This can be
             # addressed later, when the internal API is made agnostic of
             # the fitting backend (astropy vs our own).
-            raise PAHFITModelError("Fit with fewr than 2 components not allowed!")
+            raise PAHFITModelError("Fit with fewer than 2 components not allowed!")
 
         # Some translation rules between astropy model components and
         # feature table names and values.

--- a/pahfit/model.py
+++ b/pahfit/model.py
@@ -5,7 +5,6 @@ from astropy.modeling.fitting import LevMarLSQFitter
 from matplotlib import pyplot as plt
 import numpy as np
 
-from pahfit.helpers import find_packfile
 from pahfit.features import Features
 from pahfit.base import PAHFITBase
 from pahfit import instrument
@@ -88,8 +87,7 @@ class Model:
         Model instance
 
         """
-        path = find_packfile(pack_file)
-        features = Features.read(path)
+        features = Features.read(pack_file)
         return cls(features)
 
     @classmethod

--- a/pahfit/model.py
+++ b/pahfit/model.py
@@ -57,8 +57,8 @@ class Model:
 
         # If features table does not originate from a previous fit, and
         # hence has no unit yet, we initialize it as None.
-        if "unit" not in self.features.meta:
-            self.features.meta["unit"] = None
+        if "user_unit" not in self.features.meta:
+            self.features.meta["user_unit"] = None
 
         # if set to False, use set fwhm for lines to value in features
         # table at model construction
@@ -166,7 +166,7 @@ class Model:
 
         """
         # parse spectral data
-        self.features.meta["unit"] = spec.flux.unit
+        self.features.meta["user_unit"] = spec.flux.unit
         inst, z = self._parse_instrument_and_redshift(spec, redshift)
         _, _, _, xz, yz, _ = self._convert_spec_data(spec, z)
 
@@ -252,7 +252,7 @@ class Model:
 
         """
         # parse spectral data
-        self.features.meta["unit"] = spec.flux.unit
+        self.features.meta["user_unit"] = spec.flux.unit
         inst, z = self._parse_instrument_and_redshift(spec, redshift)
         x, _, _, xz, yz, uncz = self._convert_spec_data(spec, z)
 
@@ -420,10 +420,10 @@ class Model:
 
         # apply unit stored in features table (comes from from last fit
         # or from loading previous result from disk)
-        if self.features.meta["unit"] is None:
+        if self.features.meta["user_unit"] is None:
             flux_quantity = flux_values * u.dimensionless_unscaled
         else:
-            flux_quantity = flux_values * self.features.meta["unit"]
+            flux_quantity = flux_values * self.features.meta["user_unit"]
 
         return Spectrum1D(spectral_axis=wav * u.micron, flux=flux_quantity)
 

--- a/pahfit/tests/test_model_impl.py
+++ b/pahfit/tests/test_model_impl.py
@@ -110,17 +110,6 @@ def test_model_tabulate():
     )
     assert tab_Jy.shape == spec.shape
 
-    # with flux conversion
-    tab_MJy = model.tabulate(
-        wavelengths=spec,
-        instrumentname=spec.meta["instrument"],
-        flux_unit=u.MJy,
-    )
-    assert tab_MJy.unit == u.MJy
-    np.testing.assert_allclose(
-        tab_Jy.flux.value, tab_MJy.flux.value * 1e6, rtol=1e-6, atol=1e-12
-    )
-
 
 def test_save_load():
     _, model = default_spec_and_model_fit()

--- a/pahfit/tests/test_model_impl.py
+++ b/pahfit/tests/test_model_impl.py
@@ -3,6 +3,7 @@ from pahfit.model import Model
 import tempfile
 import numpy as np
 import os
+from astropy import units as u
 
 
 def assert_features_table_equality(features1, features2):
@@ -69,6 +70,56 @@ def test_model_edit():
     # Make sure the change is reflected in this model. Very handy that
     # we can access the right component by the feature name!
     assert astropy_model_edit[feature].temperature == newT
+
+
+def test_model_tabulate():
+    """This function has several options. The following tests runs will
+    make these more maintainable."""
+    # do not fit yet
+    spec, model = default_spec_and_model_fit(False)
+
+    # test tabulate before fitting, unit needs to be unitless
+    df = model.tabulate(
+        instrumentname="spitzer.irs.*.[12]",
+        feature_mask=model.features["kind"] == "dust_feature",
+    )
+    assert df.unit == u.dimensionless_unscaled
+
+    # with spec given (should still be dimensionless)
+    df = model.tabulate(
+        wavelengths=spec,
+        instrumentname="spitzer.irs.*.[12]",
+        feature_mask=model.features["kind"] == "dust_feature",
+    )
+    assert df.unit == u.dimensionless_unscaled
+
+    # after fitting
+    model.fit(spec)
+
+    # default wavelength grid. Unit should be the same as spec.
+    df = model.tabulate(
+        instrumentname="spitzer.irs.*.[12]",
+        feature_mask=model.features["kind"] == "dust_feature",
+    )
+    assert df.unit == spec.unit
+
+    # spec wavelength grid. Length should be the same as spec.
+    tab_Jy = model.tabulate(
+        wavelengths=spec,
+        instrumentname="spitzer.irs.*.[12]",
+    )
+    assert tab_Jy.shape == spec.shape
+
+    # with flux conversion
+    tab_MJy = model.tabulate(
+        wavelengths=spec,
+        instrumentname=spec.meta["instrument"],
+        flux_unit=u.MJy,
+    )
+    assert tab_MJy.unit == u.MJy
+    np.testing.assert_allclose(
+        tab_Jy.flux.value, tab_MJy.flux.value * 1e6, rtol=1e-6, atol=1e-12
+    )
 
 
 def test_save_load():


### PR DESCRIPTION
Adresses #248. I have not yet put in the suggested "components" option. The logic might be a bit complex once something like that is added.

Other things to note
- "wavelengths" and "spec" are separate keyword arguments. Spec is used for BOTH the wavelengths and the flux unit. "wavelengths" overrides the wavelengths of "spec". If none of the two are provided, I use a grid based on the wavelength range and fwhm of the instruments.

- Without having a reference spectrum, it's impossible to know what the flux units are (unless we store them from the last fit). For now, I resorted to the following behaviour:

    + "flux_unit" option overrides anything else
    + flux unit is derived from spec when provided
    + flux unit set to dimensionless when nothing else available

- "redshift": the provided wavelengths are assumed to be in the "observer" frame. Redshift shifts them to the "physical frame" where the model lives. This ensures that the model is evaluated correctly. The spectrum is not shifted back before output (could trivially do this if that makes more sense)

Here's some example behavior. At high redshift, we only see the features at shorter wavelengths (orange line).

![Screen Shot 2022-12-09 at 8 33 36 AM](https://user-images.githubusercontent.com/7421197/206713851-c954ada8-5493-47a0-bbc5-6732a0177b5c.png)

