### PR TITLE
Standardize units

### DIFF
--- a/pahfit/features/features.py
+++ b/pahfit/features/features.py
@@ -25,7 +25,7 @@ import astropy.units as u
 from pkg_resources import resource_filename
 from pahfit.errors import PAHFITFeatureError
 from pahfit.features.features_format import BoundedMaskedColumn, BoundedParTableFormatter
-from pahfit.units import UNITS
+import pahfit.units
 
 # Feature kinds and associated parameters
 KIND_PARAMS = {'starlight': {'temperature', 'tau'},
@@ -36,9 +36,9 @@ KIND_PARAMS = {'starlight': {'temperature', 'tau'},
                'absorption': {'wavelength', 'fwhm', 'tau', 'geometry'}}
 
 # Parameter default units: flux density/intensity/power (other units determined on fit)
-PARAM_UNITS = {'temperature': UNITS.temperature.value,
-               'wavelength': UNITS.wavelength.value,
-               'fwhm': UNITS.wavelength.value}
+PARAM_UNITS = {'temperature': pahfit.units.temperature,
+               'wavelength': pahfit.units.wavelength,
+               'fwhm': pahfit.units.wavelength}
 
 
 class UniqueKeyLoader(yaml.SafeLoader):

--- a/pahfit/features/features.py
+++ b/pahfit/features/features.py
@@ -21,7 +21,6 @@ import os
 import numpy as np
 from astropy.table import vstack, Table, TableAttribute
 from astropy.io.misc.yaml import yaml
-import astropy.units as u
 from pkg_resources import resource_filename
 from pahfit.errors import PAHFITFeatureError
 from pahfit.features.features_format import BoundedMaskedColumn, BoundedParTableFormatter
@@ -94,7 +93,7 @@ def value_bounds(val, bounds):
       ValueError: if bounds are specified and the value does not fall
           between them.
     """
-    
+
     if val is None:
         val = np.ma.masked
     if not bounds:

--- a/pahfit/features/features.py
+++ b/pahfit/features/features.py
@@ -41,24 +41,32 @@ class UniqueKeyLoader(yaml.SafeLoader):
 def value_bounds(val, bounds):
     """Compute bounds for a bounded value.
 
-    Arguments:
+    Parameters
     ----------
-      val: The value to bound.
+      val : float
+          The value to bound.
 
-      bounds: Either None for no relevant bounds (i.e. fixed), or a
-        two element iterable specifying (min, max) bounds.  Each of
-        min and max can be a numerical value, None (for infinite
-        bounds, either negative or positive, as appropriate), or a
-        string ending in:
+      bounds : float or str iterable, or None
+          Either None for no relevant bounds (i.e. fixed), or a two
+          element iterable specifying (min, max) bounds.  Each of min
+          and max can be a numerical value, None (for infinite bounds,
+          either negative or positive, as appropriate), or a string
+          ending in:
 
-          #: an absolute offset from the value
-          %: a percentage offset from the value
+            #: an absolute offset from the value
+            %: a percentage offset from the value
 
-        Offsets are necessarily negative for min bound, positive for
-        max bounds.
+          Offsets are necessarily negative for min bound, positive for
+          max bounds.
 
-    Examples:
-    ---------
+    Returns:
+    -------
+
+      The value and bounds as a 3 element tuple (value, min, max).
+          Any missing bound is replaced with the numpy `masked' value.
+
+    Notes
+    --------
 
       A bound of ('-1.5%', '0%') would indicate a minimum bound
         1.5% below the value, and a max bound at the value itself.
@@ -66,19 +74,13 @@ def value_bounds(val, bounds):
       A bound of ('-0.1#', None) would indicate a minimum bound 0.1 below
         the value, and infinite maximum bound.
 
-    Returns:
-    -------
-
-      The value, if unbounded, or a 3 element tuple (value, min, max).
-        Any missing bound is replaced with the numpy `masked' value.
-
     Raises:
     -------
 
       ValueError: if bounds are specified and the value does not fall
-        between them.
-
+          between them.
     """
+    
     if val is None:
         val = np.ma.masked
     if not bounds:
@@ -102,10 +104,16 @@ def value_bounds(val, bounds):
 
 
 class Features(Table):
-    """A class for holding PAHFIT features and their associated
-    parameter information.  Note that each parameter has an associated
-    `kind', and that each kind has an associated set of allowable
-    parameters (see _kind_params, below).
+    """A class for holding a table of PAHFIT features and associated
+    parameter information.
+
+    Note that each parameter has an associated `kind', and that each
+    kind has an associated set of allowable parameters (see
+    `_kind_params`, below).
+
+    See Also
+    --------
+    `~astropy.table.Table`: The parent table class.
     """
 
     TableFormatter = BoundedParTableFormatter
@@ -128,8 +136,22 @@ class Features(Table):
     def read(cls, file, *args, **kwargs):
         """Read a table from file.
 
-        If reading a YAML file, read it in as a science pack and
-        return the new table. Otherwise, use astropy's normal Table
+        Parameters
+        ----------
+
+          file : str
+              The name of the file to read, either a full valid path,
+              or named file in the PAHFIT science_packs directory.
+
+        Returns
+        -------
+          table : Features
+              A filled `~pahfit.features.Features` table.
+
+        Notes
+        -----
+        If reading a YAML file, reads it in as a science pack and
+        return the new table. Otherwise, uses astropy's normal Table
         reader.
         """
         if file.endswith(".yaml") or file.endswith(".yml"):
@@ -143,16 +165,7 @@ class Features(Table):
     def _read_scipack(cls, file):
         """Read a science pack specification from YAML file.
 
-        Arguments:
-        ----------
-
-          file: the name of the file, either a full valid path, or
-            named file in the PAHFIT science_packs directory.!
-
-        Returns:
-        --------
-
-          table: A filled pahfit.features.Features table.
+        For parameters and return, see `read`.
         """
 
         feat_tables = dict()
@@ -299,11 +312,11 @@ class Features(Table):
 
     @classmethod
     def _construct_table(cls, inp: dict):
-        """Construct a masked table with units from input dictionary
-        INP.  INP is a dictionary with feature names as the key, and a
+        """Construct a masked table from input dictionary INP.
+        INP is a dictionary with feature names as the keys, and a
         dictionary of feature parameters as value.  Each value in the
         feature parameter dictionary is either a value or tuple of 3
-        values for bounds.
+        values, expressing bounds.
         """
         tables = []
         for (kind, features) in inp.items():

--- a/pahfit/features/features.py
+++ b/pahfit/features/features.py
@@ -134,8 +134,8 @@ class Features(Table):
     MaskedColumn = BoundedMaskedColumn
 
     param_covar = TableAttribute(default=[])
-    _param_attrs = set(('value', 'bounds', 'tied'))  # params can have these attributes
-    _group_attrs = set(('bounds', 'features', 'kind', 'tied'))  # group-level attributes
+    _param_attrs = set(('value', 'bounds'))  # params can have these attributes
+    _group_attrs = set(('bounds', 'features', 'kind'))  # group-level attributes
     _no_bounds = set(('name', 'group', 'geometry', 'model'))  # String attributes (no bounds)
 
     @classmethod

--- a/pahfit/features/features.py
+++ b/pahfit/features/features.py
@@ -353,6 +353,11 @@ class Features(Table):
             tables.meta['_ratios'] = inp['_ratios']
         return tables
 
+    @staticmethod
+    def _index_table(tbl):
+        for indx in ('name', 'group'):
+            tbl.add_index(indx)
+
     def mask_feature(self, name, mask_value=True):
         """Mask all the parameters of a feature.
 

--- a/pahfit/features/features.py
+++ b/pahfit/features/features.py
@@ -30,7 +30,7 @@ from pahfit.features.features_format import BoundedMaskedColumn, BoundedParTable
 class UniqueKeyLoader(yaml.SafeLoader):
     def construct_mapping(self, node, deep=False):
         mapping = set()
-        for key_node, value_node in node.value:
+        for key_node, _ in node.value:
             key = self.construct_object(key_node, deep=deep)
             if key in mapping:
                 raise PAHFITFeatureError(f"Duplicate {key!r} key found in YAML.")

--- a/pahfit/features/features.py
+++ b/pahfit/features/features.py
@@ -36,9 +36,9 @@ KIND_PARAMS = {'starlight': {'temperature', 'tau'},
                'absorption': {'wavelength', 'fwhm', 'tau', 'geometry'}}
 
 # Parameter default units: flux density/intensity/power (other units determined on fit)
-PARAM_UNITS = {'temperature': UNITS.temperature,
-               'wavelength': UNITS.wavelength,
-               'fwhm': UNITS.wavelength}
+PARAM_UNITS = {'temperature': UNITS.temperature.value,
+               'wavelength': UNITS.wavelength.value,
+               'fwhm': UNITS.wavelength.value}
 
 
 class UniqueKeyLoader(yaml.SafeLoader):

--- a/pahfit/units.py
+++ b/pahfit/units.py
@@ -1,19 +1,19 @@
+from enum import Enum
 import astropy.units as u
 from astropy.units import CompositeUnit
 
-from enum import Enum
 
 # Working/default unitParameter default units: flux density/intensity/power
 # These are PAHFITs default science packs parameter and output units
 class UNITS(Enum):
     temperature = u.K
     wavelength = u.um
-    fwhm = u.um
     flux_density = u.mJy
     flux_power = CompositeUnit(1e-22, (u.W, u.m), (1, -2))
+    solid_angle = u.sr
     intensity = u.MJy / u.sr
     intensity_power = CompositeUnit(1e-10, (u.W, u.m, u.sr), (1, -2, -1))
 
-# integrated power units of 1e-22 W/m^2 (from flux) corresponds to the
-# unit 1e-10 W/m^2/sr (from intensity) if it occurs uniformly over a
-# solid angle 0.21" on a side (about a small JWST IFU pixel)
+# Note: integrated power units of 1e-22 W/m^2 (from flux) corresponds
+# to the unit 1e-10 W/m^2/sr (from intensity) if it occurs uniformly
+# over a solid angle 0.21" on a side (about a small JWST IFU pixel)

--- a/pahfit/units.py
+++ b/pahfit/units.py
@@ -1,18 +1,16 @@
-from enum import Enum
 import astropy.units as u
 from astropy.units import CompositeUnit
 
 
 # Working/default unitParameter default units: flux density/intensity/power
 # These are PAHFITs default science packs parameter and output units
-class UNITS(Enum):
-    temperature = u.K
-    wavelength = u.um
-    flux_density = u.mJy
-    flux_power = CompositeUnit(1e-22, (u.W, u.m), (1, -2))
-    solid_angle = u.sr
-    intensity = u.MJy / u.sr
-    intensity_power = CompositeUnit(1e-10, (u.W, u.m, u.sr), (1, -2, -1))
+temperature = u.K
+wavelength = u.um
+flux_density = u.mJy
+flux_power = CompositeUnit(1e-22, (u.W, u.m), (1, -2))
+solid_angle = u.sr
+intensity = u.MJy / u.sr
+intensity_power = CompositeUnit(1e-10, (u.W, u.m, u.sr), (1, -2, -1))
 
 # Note: integrated power units of 1e-22 W/m^2 (from flux) corresponds
 # to the unit 1e-10 W/m^2/sr (from intensity) if it occurs uniformly

--- a/pahfit/units.py
+++ b/pahfit/units.py
@@ -1,0 +1,19 @@
+import astropy.units as u
+from astropy.units import CompositeUnit
+
+from enum import Enum
+
+# Working/default unitParameter default units: flux density/intensity/power
+# These are PAHFITs default science packs parameter and output units
+class UNITS(Enum):
+    temperature = u.K
+    wavelength = u.um
+    fwhm = u.um
+    flux_density = u.mJy
+    flux_power = CompositeUnit(1e-22, (u.W, u.m), (1, -2))
+    intensity = u.MJy / u.sr
+    intensity_power = CompositeUnit(1e-10, (u.W, u.m, u.sr), (1, -2, -1))
+
+# integrated power units of 1e-22 W/m^2 (from flux) corresponds to the
+# unit 1e-10 W/m^2/sr (from intensity) if it occurs uniformly over a
+# solid angle 0.21" on a side (about a small JWST IFU pixel)


### PR DESCRIPTION
## What 
This introduces a new file `units.py` which standardizes the units for science-packs, and eventually for the entire `Features`->`Model`->`Fitter` chain. 

## Why

This will:

1. make a proper AREA-based Gaussian/Drude fitter possible (see #225)
2. standardize the report of value in results `Features` tables
3. ensure most values are within say 5 dex of unity for table glance-ability and to helping with underflow.  

**Note**: we will _convert_ any user input units into this format, and optionally convert tabulated/plotted output to the user's spectral units.  But for specifying the _PAHFIT science model_ to be fitted itself, these are the working units [1]. 

See [this comment](https://github.com/PAHFIT/pahfit/issues/28#issuecomment-1349676272) for information on how we can leverage `astropy.units` to understand user-input spectral units, e.g. to discriminate between flux density and spectral intensity (aka surface brightness).

## Proposed PAHFIT working + output units summary:

| Type | Working Unit | 
| ----- | ------------- |
| Wavelength/FWHM/spectral_axis[2] | µm | 
| Temperature[2]| K |
| Flux density | mJy | 
| Flux power | 1e-22 W/m<sup>2</sup> | 
| — OR — |
| Surface Brightness/Intensity | MJy/sr | 
| Surface Brightness Power | 1e-10 W/m<sup>2</sup>/sr |

[1] Internally, fitters may adopt any different units for convenience or other reasons, but that is a hidden implementation detail.  For the user, these will be the working units.
[2] These are already effectively standards in our science packs