### PR TITLE
Workarounds for issues with Features column definition and formatting

### DIFF
--- a/pahfit/features/features.py
+++ b/pahfit/features/features.py
@@ -110,6 +110,7 @@ class Features(Table):
 
     TableFormatter = BoundedParTableFormatter
     MaskedColumn = BoundedMaskedColumn
+    Column = BoundedMaskedColumn
 
     param_covar = TableAttribute(default=[])
     _kind_params = {'starlight': {'temperature', 'tau'},

--- a/pahfit/features/features_format.py
+++ b/pahfit/features/features_format.py
@@ -6,11 +6,16 @@ from astropy.table.pprint import TableFormatter
 # * Special table formatting for bounded (val, min, max) values
 def fmt_func(fmt):
     def _fmt(v):
-        if ma.is_masked(v[0]):
-            return "  <n/a>  "
-        if ma.is_masked(v[1]):
-            return f"{v[0]:{fmt}} (Fixed)"
-        return f"{v[0]:{fmt}} ({v[1]:{fmt}}, {v[2]:{fmt}})"
+        try:
+            if ma.is_masked(v[0]):
+                return "  masked  "
+            if ma.is_masked(v[1]):
+                return f"{v[0]:{fmt}} (Fixed)"
+            return f"{v[0]:{fmt}} ({v[1]:{fmt}}, {v[2]:{fmt}})"
+        except Exception:
+            # print(f"problem in _fmt: v = {v}, fmt = {fmt}, type(fmt) = {type(fmt)}")
+            # raise e
+            return f"{v:0.4g}"
 
     return _fmt
 
@@ -24,8 +29,7 @@ class BoundedMaskedColumn(MaskedColumn):
 
     @property
     def shape(self):
-        sh = super().shape
-        return sh[0:-1] if self._omit_shape and len(sh) > 1 else sh
+        return super().shape
 
     def is_fixed(self):
         return ma.getmask(self)[:, 1:].all(1)
@@ -37,17 +41,47 @@ class BoundedParTableFormatter(TableFormatter):
     'var', 'min', and 'max'.  To be set as Table's `TableFormatter'.
     """
 
-    def _pformat_table(self, table, *args, **kwargs):
-        bpcols = []
-        try:
-            colsh = [(col, col.shape) for col in table.columns.values()]
-            BoundedMaskedColumn._omit_shape = True
-            for col, sh in colsh:
-                if len(sh) == 2 and sh[1] == 3:
-                    bpcols.append((col, col.info.format))
-                    col.info.format = fmt_func(col.info.format or "g")
-            return super()._pformat_table(table, *args, **kwargs)
-        finally:
-            BoundedMaskedColumn._omit_shape = False
-            for col, fmt in bpcols:
-                col.info.format = fmt
+    def _pformat_col(
+        self,
+        col,
+        max_lines=None,
+        **kwargs,
+    ):
+        default_strings, outs = super()._pformat_col(col, max_lines, **kwargs)
+        has_bounds = len(col.shape) == 2 and col.shape[1] == 3
+        if not has_bounds:
+            strings = default_strings
+        else:
+            # copy the header strings
+            strings = default_strings[: outs["n_header"]]
+
+            # modify output of the numerical lines
+            # data index = line index - n_header
+            after_ellipsis = False
+            data_strings = default_strings[outs["n_header"] :]
+            for i, line in enumerate(data_strings):
+                if "..." in line or "table" in line:
+                    # generic ellipsis line
+                    strings.append(line)
+                    after_ellipsis = True
+                elif "-- .. --" in line:
+                    # all masked
+                    strings.append(line.replace("-- .. --", "--"))
+                elif ".. --" in line:
+                    # value but masked bound
+                    strings.append(line.replace(".. --", "(fixed)"))
+                else:
+                    # deal with case where a "..." row is present, by counting from the end
+                    # show -1 if at the last data string
+                    if after_ellipsis:
+                        d_from_end = len(data_strings) - i
+                        if outs["show_length"]:
+                            # need to add 1 because "length = xx rows" is the last row in this case
+                            d_from_end -= 1
+                        row_index = -d_from_end
+                    else:
+                        row_index = i
+
+                    strings.append(fmt_func(col.info.format or "0.4g")(col[row_index]))
+
+        return strings, outs


### PR DESCRIPTION
There were a series of strange issues with the Features class in certain edge cases
- There are only dust features (#274)
- There are only lines (#266)
- Exceptions are thrown due to a mismatch in the number of elements in a table entry (#273)

To solve #274, both the Column and MaskedColumn definitions of Features were set to BoundedMaskedColumn.
The formatting hacks for Features were revised to deal with the above change and with #273 and #266.

The new formatting method, takes the default output of the formatter (using if/else to cover all possible strings created for a 3-tuple), and modifies it through string replacements.

This pull request is independent from #281, so one can go in after the other (at most a simple rebase required).