### PR TITLE
Standardize units (extended)

### DIFF
--- a/pahfit/features/features.py
+++ b/pahfit/features/features.py
@@ -25,7 +25,7 @@ import astropy.units as u
 from importlib import resources
 from pahfit.errors import PAHFITFeatureError
 from pahfit.features.features_format import BoundedMaskedColumn, BoundedParTableFormatter
-from pahfit.units import UNITS
+import pahfit.units
 
 # Feature kinds and associated parameters
 KIND_PARAMS = {'starlight': {'temperature', 'tau'},
@@ -36,9 +36,9 @@ KIND_PARAMS = {'starlight': {'temperature', 'tau'},
                'absorption': {'wavelength', 'fwhm', 'tau', 'geometry'}}
 
 # Parameter default units: flux density/intensity/power (other units determined on fit)
-PARAM_UNITS = {'temperature': UNITS.temperature.value,
-               'wavelength': UNITS.wavelength.value,
-               'fwhm': UNITS.wavelength.value}
+PARAM_UNITS = {'temperature': pahfit.units.temperature,
+               'wavelength': pahfit.units.wavelength,
+               'fwhm': pahfit.units.wavelength}
 
 
 class UniqueKeyLoader(yaml.SafeLoader):

--- a/pahfit/features/features.py
+++ b/pahfit/features/features.py
@@ -25,6 +25,20 @@ import astropy.units as u
 from importlib import resources
 from pahfit.errors import PAHFITFeatureError
 from pahfit.features.features_format import BoundedMaskedColumn, BoundedParTableFormatter
+from pahfit.units import UNITS
+
+# Feature kinds and associated parameters
+KIND_PARAMS = {'starlight': {'temperature', 'tau'},
+               'dust_continuum': {'temperature', 'tau'},
+               'line': {'wavelength', 'power'},  # 'fwhm', Instrument Pack detail!
+               'dust_feature': {'wavelength', 'fwhm', 'power'},
+               'attenuation': {'model', 'tau', 'geometry'},
+               'absorption': {'wavelength', 'fwhm', 'tau', 'geometry'}}
+
+# Parameter default units: flux density/intensity/power (other units determined on fit)
+PARAM_UNITS = {'temperature': UNITS.temperature,
+               'wavelength': UNITS.wavelength,
+               'fwhm': UNITS.wavelength}
 
 
 class UniqueKeyLoader(yaml.SafeLoader):
@@ -102,26 +116,24 @@ def value_bounds(val, bounds):
 
 
 class Features(Table):
-    """A class for holding PAHFIT features and their associated
-    parameter information.  Note that each parameter has an associated
-    `kind', and that each kind has an associated set of allowable
-    parameters (see _kind_params, below).
+    """A class for holding a table of PAHFIT features and associated
+    parameter information.
+
+    Note that each parameter has an associated `kind', and that each
+    kind has an associated set of allowable parameters (see
+    `KIND_PARAMS`).
+
+    See Also
+    --------
+    `~astropy.table.Table`: The parent table class.
     """
 
     TableFormatter = BoundedParTableFormatter
     MaskedColumn = BoundedMaskedColumn
 
     param_covar = TableAttribute(default=[])
-    _kind_params = {'starlight': {'temperature', 'tau'},
-                    'dust_continuum': {'temperature', 'tau'},
-                    'line': {'wavelength', 'power'},  # 'fwhm', Instrument Pack detail!
-                    'dust_feature': {'wavelength', 'fwhm', 'power'},
-                    'attenuation': {'model', 'tau', 'geometry'},
-                    'absorption': {'wavelength', 'fwhm', 'tau', 'geometry'}}
-
-    _units = {'temperature': u.K, 'wavelength': u.um, 'fwhm': u.um}
-    _group_attrs = set(('bounds', 'features', 'kind'))  # group-level attributes
-    _param_attrs = set(('value', 'bounds'))  # Each parameter can have these attributes
+    _param_attrs = set(('value', 'bounds', 'tied'))  # params can have these attributes
+    _group_attrs = set(('bounds', 'features', 'kind', 'tied'))  # group-level attributes
     _no_bounds = set(('name', 'group', 'geometry', 'model'))  # String attributes (no bounds)
 
     @classmethod
@@ -178,7 +190,7 @@ class Features(Table):
                 raise PAHFITFeatureError(f"No kind found for {name}\n\t{file}")
 
             try:
-                valid_params = cls._kind_params[kind]
+                valid_params = KIND_PARAMS[kind]
             except KeyError:
                 raise PAHFITFeatureError(f"Unknown kind {kind} for {name}\n\t{file}")
             unknown_params = [x for x in keys
@@ -263,7 +275,7 @@ class Features(Table):
         t[kind][name]['group'] = group
         t[kind][name]['kind'] = kind
         for (param, val) in pars.items():
-            if param not in cls._kind_params[kind]:
+            if param not in KIND_PARAMS[kind]:
                 continue
             if isinstance(val, dict):  # A param attribute dictionary
                 unknown_attrs = [x for x in val.keys() if x not in cls._param_attrs]
@@ -306,10 +318,12 @@ class Features(Table):
         """
         tables = []
         for (kind, features) in inp.items():
-            kind_params = cls._kind_params[kind]  # All params for this kind
+            if kind == "_ratios":
+                continue
+            kp = KIND_PARAMS[kind]  # All params for this kind
             rows = []
             for (name, params) in features.items():
-                for missing in kind_params - params.keys():
+                for missing in kp - params.keys():
                     if missing in cls._no_bounds:
                         params[missing] = 0.0
                     else:
@@ -317,15 +331,18 @@ class Features(Table):
                 rows.append(dict(name=name, **params))
             table_columns = rows[0].keys()
             t = cls(rows, names=table_columns)
-            for p in cls._kind_params[kind]:
+            for p in KIND_PARAMS[kind]:
                 if p not in cls._no_bounds:
                     t[p].info.format = "0.4g"  # Nice format (customized by Formatter)
             tables.append(t)
         tables = vstack(tables)
         for cn, col in tables.columns.items():
-            if cn in cls._units:
-                col.unit = cls._units[cn]
-        tables.add_index('name')
+            if cn in PARAM_UNITS:
+                col.unit = PARAM_UNITS[cn]
+        cls._index_table(tables)
+
+        if '_ratios' in inp:
+            tables.meta['_ratios'] = inp['_ratios']
         return tables
 
     def mask_feature(self, name, mask_value=True):
@@ -344,7 +361,7 @@ class Features(Table):
 
         """
         row = self.loc[name]
-        relevant_params = self._kind_params[row['kind']]
+        relevant_params = KIND_PARAMS[row['kind']]
         for col_name in relevant_params:
             if col_name in self._no_bounds:
                 # these are all strings, so can't mask

--- a/pahfit/features/features.py
+++ b/pahfit/features/features.py
@@ -132,8 +132,8 @@ class Features(Table):
     MaskedColumn = BoundedMaskedColumn
 
     param_covar = TableAttribute(default=[])
-    _param_attrs = set(('value', 'bounds', 'tied'))  # params can have these attributes
-    _group_attrs = set(('bounds', 'features', 'kind', 'tied'))  # group-level attributes
+    _param_attrs = set(('value', 'bounds'))  # params can have these attributes
+    _group_attrs = set(('bounds', 'features', 'kind'))  # group-level attributes
     _no_bounds = set(('name', 'group', 'geometry', 'model'))  # String attributes (no bounds)
 
     @classmethod

--- a/pahfit/features/features.py
+++ b/pahfit/features/features.py
@@ -21,7 +21,6 @@ import os
 import numpy as np
 from astropy.table import vstack, Table, TableAttribute
 from astropy.io.misc.yaml import yaml
-import astropy.units as u
 from importlib import resources
 from pahfit.errors import PAHFITFeatureError
 from pahfit.features.features_format import BoundedMaskedColumn, BoundedParTableFormatter

--- a/pahfit/features/features.py
+++ b/pahfit/features/features.py
@@ -345,6 +345,11 @@ class Features(Table):
             tables.meta['_ratios'] = inp['_ratios']
         return tables
 
+    @staticmethod
+    def _index_table(tbl):
+        for indx in ('name', 'group'):
+            tbl.add_index(indx)
+
     def mask_feature(self, name, mask_value=True):
         """Mask all the parameters of a feature.
 

--- a/pahfit/features/features.py
+++ b/pahfit/features/features.py
@@ -30,7 +30,7 @@ from pahfit.features.features_format import BoundedMaskedColumn, BoundedParTable
 class UniqueKeyLoader(yaml.SafeLoader):
     def construct_mapping(self, node, deep=False):
         mapping = set()
-        for key_node, value_node in node.value:
+        for key_node, _ in node.value:
             key = self.construct_object(key_node, deep=deep)
             if key in mapping:
                 raise PAHFITFeatureError(f"Duplicate {key!r} key found in YAML.")

--- a/pahfit/features/features.py
+++ b/pahfit/features/features.py
@@ -36,9 +36,9 @@ KIND_PARAMS = {'starlight': {'temperature', 'tau'},
                'absorption': {'wavelength', 'fwhm', 'tau', 'geometry'}}
 
 # Parameter default units: flux density/intensity/power (other units determined on fit)
-PARAM_UNITS = {'temperature': UNITS.temperature,
-               'wavelength': UNITS.wavelength,
-               'fwhm': UNITS.wavelength}
+PARAM_UNITS = {'temperature': UNITS.temperature.value,
+               'wavelength': UNITS.wavelength.value,
+               'fwhm': UNITS.wavelength.value}
 
 
 class UniqueKeyLoader(yaml.SafeLoader):

--- a/pahfit/features/features.py
+++ b/pahfit/features/features.py
@@ -35,9 +35,13 @@ KIND_PARAMS = {'starlight': {'temperature', 'tau'},
                'absorption': {'wavelength', 'fwhm', 'tau', 'geometry'}}
 
 # Parameter default units: flux density/intensity/power (other units determined on fit)
+# Note: power is actually amplitude for now. Change this to
+# intensity_power when the power features are implemented.
+
 PARAM_UNITS = {'temperature': pahfit.units.temperature,
                'wavelength': pahfit.units.wavelength,
-               'fwhm': pahfit.units.wavelength}
+               'fwhm': pahfit.units.wavelength,
+               'power': pahfit.units.intensity}
 
 
 class UniqueKeyLoader(yaml.SafeLoader):

--- a/pahfit/model.py
+++ b/pahfit/model.py
@@ -307,7 +307,7 @@ class Model:
 
         """
         if not spec.flux.unit.is_equivalent(units.intensity):
-            raise PAHFITModelError("PAHFIT only supports intensity units, i.e. convertible to MJy / sr.")
+            raise PAHFITModelError("For now, PAHFIT only supports intensity units, i.e. convertible to MJy / sr.")
         y = spec.flux.to(units.intensity).value
         x = spec.spectral_axis.to(u.micron).value
         unc = (spec.uncertainty.array * spec.flux.unit).to(units.intensity).value

--- a/pahfit/model.py
+++ b/pahfit/model.py
@@ -12,6 +12,7 @@ from pahfit.base import PAHFITBase
 from pahfit import instrument
 from pahfit.errors import PAHFITModelError
 from pahfit.component_models import BlackBody1D
+from pahfit import units
 
 
 class Model:
@@ -288,9 +289,12 @@ class Model:
 
     @staticmethod
     def _convert_spec_data(spec, z):
-        """
-        Turn astropy quantities stored in Spectrum1D into fittable
-        numbers.
+        """Convert Spectrum1D Quantities to fittable numbers.
+
+        The unit of the input spectrum has to be a multiple of MJy / sr,
+        the internal intensity unit. The output of this function
+        consists of simple unitless arrays (the numbers in these arrays
+        are assumed to be consistent with the internal units).
 
         Also corrects for redshift.
 
@@ -300,10 +304,13 @@ class Model:
 
         xz, yz, uncz: wavelength in micron, flux, uncertainty
             corrected for redshift
+
         """
+        if not spec.flux.unit.is_equivalent(units.intensity):
+            raise PAHFITModelError("PAHFIT only supports intensity units, i.e. convertible to MJy / sr.")
+        y = spec.flux.to(units.intensity).value
         x = spec.spectral_axis.to(u.micron).value
-        y = spec.flux.value
-        unc = spec.uncertainty.array
+        unc = (spec.uncertainty.array * spec.flux.unit).to(units.intensity).value
 
         # transform observed wavelength to "physical" wavelength
         xz = x / (1 + z)  # wavelength shorter

--- a/pahfit/units.py
+++ b/pahfit/units.py
@@ -1,19 +1,19 @@
+from enum import Enum
 import astropy.units as u
 from astropy.units import CompositeUnit
 
-from enum import Enum
 
 # Working/default unitParameter default units: flux density/intensity/power
 # These are PAHFITs default science packs parameter and output units
 class UNITS(Enum):
     temperature = u.K
     wavelength = u.um
-    fwhm = u.um
     flux_density = u.mJy
     flux_power = CompositeUnit(1e-22, (u.W, u.m), (1, -2))
+    solid_angle = u.sr
     intensity = u.MJy / u.sr
     intensity_power = CompositeUnit(1e-10, (u.W, u.m, u.sr), (1, -2, -1))
 
-# integrated power units of 1e-22 W/m^2 (from flux) corresponds to the
-# unit 1e-10 W/m^2/sr (from intensity) if it occurs uniformly over a
-# solid angle 0.21" on a side (about a small JWST IFU pixel)
+# Note: integrated power units of 1e-22 W/m^2 (from flux) corresponds
+# to the unit 1e-10 W/m^2/sr (from intensity) if it occurs uniformly
+# over a solid angle 0.21" on a side (about a small JWST IFU pixel)

--- a/pahfit/units.py
+++ b/pahfit/units.py
@@ -1,18 +1,16 @@
-from enum import Enum
 import astropy.units as u
 from astropy.units import CompositeUnit
 
 
 # Working/default unitParameter default units: flux density/intensity/power
 # These are PAHFITs default science packs parameter and output units
-class UNITS(Enum):
-    temperature = u.K
-    wavelength = u.um
-    flux_density = u.mJy
-    flux_power = CompositeUnit(1e-22, (u.W, u.m), (1, -2))
-    solid_angle = u.sr
-    intensity = u.MJy / u.sr
-    intensity_power = CompositeUnit(1e-10, (u.W, u.m, u.sr), (1, -2, -1))
+temperature = u.K
+wavelength = u.um
+flux_density = u.mJy
+flux_power = CompositeUnit(1e-22, (u.W, u.m), (1, -2))
+solid_angle = u.sr
+intensity = u.MJy / u.sr
+intensity_power = CompositeUnit(1e-10, (u.W, u.m, u.sr), (1, -2, -1))
 
 # Note: integrated power units of 1e-22 W/m^2 (from flux) corresponds
 # to the unit 1e-10 W/m^2/sr (from intensity) if it occurs uniformly

--- a/pahfit/units.py
+++ b/pahfit/units.py
@@ -1,0 +1,19 @@
+import astropy.units as u
+from astropy.units import CompositeUnit
+
+from enum import Enum
+
+# Working/default unitParameter default units: flux density/intensity/power
+# These are PAHFITs default science packs parameter and output units
+class UNITS(Enum):
+    temperature = u.K
+    wavelength = u.um
+    fwhm = u.um
+    flux_density = u.mJy
+    flux_power = CompositeUnit(1e-22, (u.W, u.m), (1, -2))
+    intensity = u.MJy / u.sr
+    intensity_power = CompositeUnit(1e-10, (u.W, u.m, u.sr), (1, -2, -1))
+
+# integrated power units of 1e-22 W/m^2 (from flux) corresponds to the
+# unit 1e-10 W/m^2/sr (from intensity) if it occurs uniformly over a
+# solid angle 0.21" on a side (about a small JWST IFU pixel)


### PR DESCRIPTION
This includes the exact same commits as #259 , but adds a few extra changes
- Units for 'power' columns. Set to 'amplitude units' for now, i.e. `units.intensity` or MJy / sr. After the "power gaussian" and "power drude" have been implemented, we will switch this to `units.intensity_power`
- error message that makes clear that only units compatible with MJy / sr are supported 
- conversion of the spectrum and wavelengths to internal units when the user input is parsed
