### PR TITLE
Porting features from the Orion Bar paper branch

### DIFF
--- a/pahfit/features/features.py
+++ b/pahfit/features/features.py
@@ -32,7 +32,7 @@ import pahfit.units
 
 # Feature kinds and associated parameters
 KIND_PARAMS = {'starlight': {'temperature', 'tau'},
-               'dust_continuum': {'temperature', 'tau'},
+               'dust_continuum': {'model', 'temperature', 'tau'},
                'line': {'wavelength', 'power'},  # 'fwhm', Instrument Pack detail!
                'dust_feature': {'wavelength', 'fwhm', 'power'},
                'attenuation': {'model', 'tau', 'geometry'},

--- a/pahfit/fitters/ap_components.py
+++ b/pahfit/fitters/ap_components.py
@@ -41,7 +41,9 @@ class ModifiedBlackBody1D(BlackBody1D):
 
     @staticmethod
     def evaluate(x, amplitude, temperature):
-        return BlackBody1D.evaluate(x, amplitude, temperature) * ((9.7 / x) ** 2)
+        bb = BlackBody1D.evaluate(x, 1, temperature) * ((9.7 / x) ** 2)
+        bb_ref = BlackBody1D.evaluate(17, 1, temperature) * ((9.7 / 17) ** 2)
+        return amplitude * bb / bb_ref
 
 
 class SpecialModifiedBlackBody1D(BlackBody1D):
@@ -59,12 +61,19 @@ class SpecialModifiedBlackBody1D(BlackBody1D):
 
     absorption_curve = G23()
     Rv = 5.5
+    wref = 17
+
+    @classmethod
+    def evaluate_not_normalized(cls, x, temperature):
+        return BlackBody1D.evaluate(x, 1, temperature) * cls.absorption_curve.evaluate(
+            x * u.micron, Rv=cls.Rv
+        )
 
     @classmethod
     def evaluate(cls, x, amplitude, temperature):
-        return BlackBody1D.evaluate(
-            x, amplitude, temperature
-        ) * cls.absorption_curve.evaluate(x * u.micron, Rv=cls.Rv)
+        bb = cls.evaluate_not_normalized(x, temperature)
+        bb_ref = cls.evaluate_not_normalized(cls.wref, temperature)
+        return amplitude * bb / bb_ref
 
 
 class S07_attenuation(Fittable1DModel):

--- a/pahfit/fitters/ap_components.py
+++ b/pahfit/fitters/ap_components.py
@@ -88,7 +88,7 @@ class SpecialModifiedBlackBody1D(BlackBody1D):
             29.99954211,
         ]
     )
-    _interp_y = absorption_curve.extinguish(_interp_grid * u.micron, Av=1, Rv=5.5)
+    _interp_y = absorption_curve.extinguish(_interp_grid * u.micron, Av=1)
     _interp = interpolate.CubicSpline(_interp_grid, _interp_y)
     print("prepared cubic spline for special continuum")
 

--- a/pahfit/fitters/ap_components.py
+++ b/pahfit/fitters/ap_components.py
@@ -64,8 +64,7 @@ class SpecialModifiedBlackBody1D(BlackBody1D):
 
     """
 
-    absorption_curve = G23()
-    Rv = 5.5
+    absorption_curve = G23(Rv=5.5)
 
     # a spline interpolation of a log-grid sampling with 14 points is
     # already accurate up to 3%. Let's see if evaluating this way will
@@ -89,7 +88,7 @@ class SpecialModifiedBlackBody1D(BlackBody1D):
             29.99954211,
         ]
     )
-    _interp_y = absorption_curve.evaluate(_interp_grid * u.micron, Rv=5.5)
+    _interp_y = absorption_curve.extinguish(_interp_grid * u.micron, Av=1, Rv=5.5)
     _interp = interpolate.CubicSpline(_interp_grid, _interp_y)
     print("prepared cubic spline for special continuum")
 

--- a/pahfit/fitters/ap_components.py
+++ b/pahfit/fitters/ap_components.py
@@ -88,7 +88,7 @@ class SpecialModifiedBlackBody1D(BlackBody1D):
             29.99954211,
         ]
     )
-    _interp_y = absorption_curve.extinguish(_interp_grid * u.micron, Av=1)
+    _interp_y = absorption_curve(_interp_grid * u.micron)
     _interp = interpolate.CubicSpline(_interp_grid, _interp_y)
     print("prepared cubic spline for special continuum")
 

--- a/pahfit/fitters/ap_components.py
+++ b/pahfit/fitters/ap_components.py
@@ -11,6 +11,14 @@ from astropy import units as u
 __all__ = ["BlackBody1D", "ModifiedBlackBody1D", "S07_attenuation", "att_Drude1D"]
 
 
+def bb(x, temperature):
+    return (
+        3.9728917e13  # 2 h c/µm^3 -> MJy
+        / x**3
+        / (np.exp(1.4387752e4 / x / temperature) - 1.0)
+    )  # h c/micron k K
+
+
 class BlackBody1D(Fittable1DModel):
     """
     A blackbody component.
@@ -22,15 +30,13 @@ class BlackBody1D(Fittable1DModel):
     amplitude = Parameter()
     temperature = Parameter()
 
+    norm = bb(3, 5000)
+    print("norm for bb is", norm)
+
     @staticmethod
     def evaluate(x, amplitude, temperature):
         """ """
-        return (
-            amplitude
-            * 3.9728917e13 # 2 h c/µm^3 -> MJy
-            / x**3 
-            / (np.exp(1.4387752e4 / x / temperature) - 1.0)  # h c/micron k K
-        )
+        return amplitude * bb(x, temperature) / BlackBody1D.norm
 
 
 class ModifiedBlackBody1D(BlackBody1D):

--- a/pahfit/fitters/ap_fitter.py
+++ b/pahfit/fitters/ap_fitter.py
@@ -276,23 +276,23 @@ class APFitter(Fitter):
 
         self.fit_info = []
 
-        fit = LevMarLSQFitter(calc_uncertainties=True)
-        astropy_result = fit(
-            self.model,
-            lam[mask],
-            flux[mask],
-            weights=w[mask],
-            maxiter=maxiter,
-            epsilon=1e-10,
-            acc=1e-10,
-        )
-        # let's see what running this after lev mar does. Maybe it
-        # improves the continuum fitting somewhat (less "sticky" to the
-        # tau = 0 bound?)
-        print("LevMarLSQ fit done, continuing with TRFLSQ")
+        # fit = LevMarLSQFitter(calc_uncertainties=True)
+        # astropy_result = fit(
+        #     self.model,
+        #     lam[mask],
+        #     flux[mask],
+        #     weights=w[mask],
+        #     maxiter=maxiter,
+        #     epsilon=1e-10,
+        #     acc=1e-10,
+        # )
+        # # let's see what running this after lev mar does. Maybe it
+        # # improves the continuum fitting somewhat (less "sticky" to the
+        # # tau = 0 bound?)
+        # print("LevMarLSQ fit done, continuing with TRFLSQ")
         fit = TRFLSQFitter(calc_uncertainties=True)
         astropy_result = fit(
-            astropy_result,
+            self.model,
             lam[mask],
             flux[mask],
             weights=w[mask],

--- a/pahfit/fitters/ap_fitter.py
+++ b/pahfit/fitters/ap_fitter.py
@@ -276,23 +276,24 @@ class APFitter(Fitter):
 
         self.fit_info = []
 
-        # fit = LevMarLSQFitter(calc_uncertainties=True)
-        # astropy_result = fit(
-        #     self.model,
-        #     lam[mask],
-        #     flux[mask],
-        #     weights=w[mask],
-        #     maxiter=maxiter,
-        #     epsilon=1e-10,
-        #     acc=1e-10,
-        # )
-        # # let's see what running this after lev mar does. Maybe it
-        # # improves the continuum fitting somewhat (less "sticky" to the
-        # # tau = 0 bound?)
-        # print("LevMarLSQ fit done, continuing with TRFLSQ")
-        fit = TRFLSQFitter(calc_uncertainties=True)
+        fit = LevMarLSQFitter(calc_uncertainties=True)
         astropy_result = fit(
             self.model,
+            lam[mask],
+            flux[mask],
+            weights=w[mask],
+            maxiter=maxiter,
+            epsilon=1e-10,
+            acc=1e-10,
+        )
+        print("LevMarLSQ fit done, continuing with TRFLSQ")
+        # let's see what running this after lev mar does. Maybe it
+        # # improves the continuum fitting somewhat (less "sticky" to the
+        # # tau = 0 bound?)
+        fit = TRFLSQFitter(calc_uncertainties=True)
+        astropy_result = fit(
+            astropy_result,
+            # self.model,
             lam[mask],
             flux[mask],
             weights=w[mask],

--- a/pahfit/fitters/ap_fitter.py
+++ b/pahfit/fitters/ap_fitter.py
@@ -297,6 +297,9 @@ class APFitter(Fitter):
         elif method_str == "trf":
             fitter_cls = TRFLSQFitter
             fitter_call_kwargs["acc"] = 1e-15
+        else:
+            raise ValueError(f"fit method \"{method_str}\" is not supported."
+                             "Valid options are \"lm\" or \"trf\"")
 
         print(f"Running {method_str}lsq fit")
         fit = fitter_cls(calc_uncertainties=True)

--- a/pahfit/fitters/ap_fitter.py
+++ b/pahfit/fitters/ap_fitter.py
@@ -9,7 +9,7 @@ from .ap_components import (
     PowerDrude1D,
     PowerGaussian1D,
 )
-from astropy.modeling.fitting import LevMarLSQFitter
+from astropy.modeling.fitting import LevMarLSQFitter, TRFLSQFitter
 import numpy as np
 
 
@@ -286,6 +286,21 @@ class APFitter(Fitter):
             epsilon=1e-10,
             acc=1e-10,
         )
+        # let's see what running this after lev mar does. Maybe it
+        # improves the continuum fitting somewhat (less "sticky" to the
+        # tau = 0 bound?)
+        print("LevMarLSQ fit done, continuing with TRFLSQ")
+        fit = TRFLSQFitter(calc_uncertainties=True)
+        astropy_result = fit(
+            astropy_result,
+            lam[mask],
+            flux[mask],
+            weights=w[mask],
+            maxiter=maxiter,
+            epsilon=1e-10,
+            acc=1e-10,
+        )
+
         self.fit_info = fit.fit_info
         self.model = astropy_result
         self.message = fit.fit_info["message"]

--- a/pahfit/fitters/ap_fitter.py
+++ b/pahfit/fitters/ap_fitter.py
@@ -3,6 +3,7 @@ from pahfit.errors import PAHFITModelError
 from .ap_components import (
     BlackBody1D,
     ModifiedBlackBody1D,
+    SpecialModifiedBlackBody1D,
     S07_attenuation,
     att_Drude1D,
     PowerDrude1D,
@@ -137,18 +138,30 @@ class APFitter(Fitter):
         )
         self._add_component(BlackBody1D, **kwargs)
 
-    def add_feature_dust_continuum(self, name, temperature, tau):
+    def add_feature_dust_continuum(self, name, temperature, tau, model="default"):
         """Register a ModifiedBlackBody1D.
 
         Analogous. Temperature and tau are used as temperature and
         amplitude
+
+        Parameters
+        ----------
+        model : str (available values: 'default' and 'special')
+            Keyword to activate alternate continuum shapes. 'default' is
+            a modified blackbody with a lambda**-2 factor. With
+            model='special', the modification factor is the MW average
+            extinction law for Rv=5.5.
 
         """
         self.feature_types[name] = "dust_continuum"
         kwargs = self._astropy_model_kwargs(
             name, ["temperature", "amplitude"], [temperature, tau]
         )
-        self._add_component(ModifiedBlackBody1D, **kwargs)
+        if model == "special":
+            ap_class = SpecialModifiedBlackBody1D
+        else:
+            ap_class = ModifiedBlackBody1D
+        self._add_component(ap_class, **kwargs)
 
     def add_feature_line(self, name, power, wavelength, fwhm):
         """Register a PowerGaussian1D

--- a/pahfit/fitters/ap_fitter.py
+++ b/pahfit/fitters/ap_fitter.py
@@ -70,6 +70,7 @@ class APFitter(Fitter):
         self.feature_types = {}
         self.model = None
         self.message = None
+        self.methods = ["lm", "trf"]
 
     def finalize(self):
         """Sum the registered components into one CompoundModel.
@@ -235,7 +236,10 @@ class APFitter(Fitter):
         """
         return self.model(lam)
 
-    def fit(self, lam, flux, unc, maxiter=10000):
+    def fit_methods_available(self):
+        return self.methods
+
+    def fit(self, lam, flux, unc, maxiter=10000, method=None):
         """Fit the internal model using the astropy fitter.
 
         The fitter class is unit agnostic, and deal with the numbers the
@@ -267,6 +271,10 @@ class APFitter(Fitter):
         unc : array
             Uncertainty on rest frame flux. Same units as flux.
 
+        method : str
+            Fit method. Available options: "lm" will use
+            LevMarLSQFitter. "trf" will use TRFLSQFitter.
+
         """
         # clean, because astropy does not like nan
         w = 1 / unc
@@ -276,35 +284,35 @@ class APFitter(Fitter):
 
         self.fit_info = []
 
-        fit = LevMarLSQFitter(calc_uncertainties=True)
-        astropy_result = fit(
+        # select method based on given string or pick default if None
+        method_str = self.methods[0] if method is None else method
+        if method_str not in self.methods:
+            PAHFITModelError(
+                f"Selected method {method} not available for APFitter backend."
+            )
+
+        fitter_call_kwargs = dict(acc=1e-10)
+        if method_str == "lm":
+            fitter_cls = LevMarLSQFitter
+        elif method_str == "trf":
+            fitter_cls = TRFLSQFitter
+            fitter_call_kwargs["acc"] = 1e-15
+
+        print(f"Running {method_str}lsq fit")
+        fit = fitter_cls(calc_uncertainties=True)
+        temp_result = fit(
             self.model,
             lam[mask],
             flux[mask],
             weights=w[mask],
             maxiter=maxiter,
             epsilon=1e-10,
-            acc=1e-10,
-        )
-        print("LevMarLSQ fit done, continuing with TRFLSQ")
-        # let's see what running this after lev mar does. Maybe it
-        # # improves the continuum fitting somewhat (less "sticky" to the
-        # # tau = 0 bound?)
-        fit = TRFLSQFitter(calc_uncertainties=True)
-        astropy_result = fit(
-            astropy_result,
-            # self.model,
-            lam[mask],
-            flux[mask],
-            weights=w[mask],
-            maxiter=maxiter,
-            epsilon=1e-10,
-            acc=1e-10,
+            **fitter_call_kwargs,
         )
 
         self.fit_info = fit.fit_info
-        self.model = astropy_result
         self.message = fit.fit_info["message"]
+        self.model = temp_result
 
     def get_result(self, component_name):
         """Retrieve results from astropy model component.

--- a/pahfit/fitters/fitter.py
+++ b/pahfit/fitters/fitter.py
@@ -147,7 +147,11 @@ class Fitter(ABC):
         pass
 
     @abstractmethod
-    def fit(self, lam, flux, unc, maxiter=1000):
+    def fit_methods_available(self):
+        return [None]
+
+    @abstractmethod
+    def fit(self, lam, flux, unc, maxiter=1000, method=None):
         """Perform the fit using the framework of the subclass.
 
         :class:`~pahfit.fitters.Fitter` is unit agnostic, and deals
@@ -168,6 +172,11 @@ class Fitter(ABC):
 
         unc : array
             Uncertainty in the rest-frame flux.  Same units as flux.
+
+        method : str
+            Override fit method. Available options are returned by
+            fit_methods_available, of which the output depends on the
+            subclass.
         """
         pass
 

--- a/pahfit/model.py
+++ b/pahfit/model.py
@@ -231,7 +231,7 @@ class Model:
             bb = ModifiedBlackBody1D(1, temp)
             flux_ref = np.median(flux[(lam > lam_ref - 0.2) & (lam < lam_ref + 0.2)])
             amp_guess = flux_ref / bb(lam_ref)
-            return amp_guess / nbb        #np.clip(amp_guess / nbb, 0, 1.)
+            return amp_guess / nbb  # np.clip(amp_guess / nbb, 0, 1.)
 
         loop_over_non_fixed("dust_continuum", "tau", dust_continuum_guess)
 
@@ -285,8 +285,19 @@ class Model:
             loop_over_non_fixed("line", "power",
                                 lambda row: power_guess(row, line_fwhm_guess(row)))
         else:
-            loop_over_non_fixed("line", "power",
-                                lambda row: median_flux * line_fwhm_guess(row))
+            loop_over_non_fixed(
+                "line",
+                "power",
+                # approximate power = fnu * dlambda * c / lambda**2 = intensity * fwhm * c / lambda**2
+                lambda row: (
+                    (median_flux * units.intensity)
+                    * (line_fwhm_guess(row) * units.wavelength)
+                    * constants.c
+                    / (row["wavelength"]["val"] * units.wavelength) ** 2
+                )
+                .to(units.intensity_power)
+                .value,
+            )
 
         # Override the fwhms in the features table. Slightly different logic,
         # as the fwhm for lines are masked by default. TODO: leave FWHM
@@ -302,10 +313,10 @@ class Model:
                     # its elements is masked.  Table prevents setting
                     # values in such a masked array element, so we
                     # access the underlying array itself with .data
-                    self.features["fwhm"].data[row_index]['val'] = line_fwhm_guess(row)
-                    for b in ('min', 'max'):
+                    self.features["fwhm"].data[row_index]["val"] = line_fwhm_guess(row)
+                    for b in ("min", "max"):
                         self.features["fwhm"].data[row_index][b] = np.nan
-                    self.features["fwhm"].data[row_index]['frozen'] = False
+                    self.features["fwhm"].data[row_index]["frozen"] = False
                 elif not bounded_is_fixed(row["fwhm"]):
                     self.features["fwhm"].data[row_index]["val"] = line_fwhm_guess(row)
 
@@ -444,8 +455,6 @@ class Model:
                     # do not update disabled attributes (e.g. line fwhm is usually masked)
                     if not bounded_is_disabled(self.features[column][i]):
                         self.features[column]["val"][i] = value
-                    else:
-                        self.features[column][i] = (value, np.nan, np.nan)
                 except Exception as e:
                     print(f"Could not assign to attribute {name} in features table.")
                     print(f"Index {i=}")

--- a/pahfit/model.py
+++ b/pahfit/model.py
@@ -342,8 +342,15 @@ class Model:
         unc = unc_obs * (1 + z)  # uncertainty scales with flux
         return lam_obs, flux_obs, unc_obs, lam, flux, unc
 
-    def fit(self, spec: Spectrum1D, redshift=None, maxiter=1000, verbose=True,
-            use_instrument_fwhm=True):
+    def fit(
+        self,
+        spec: Spectrum1D,
+        redshift=None,
+        maxiter=1000,
+        verbose=True,
+        use_instrument_fwhm=True,
+        method=None,
+    ):
         """Fit the observed data.
 
         The model setup is based on the features table and instrument
@@ -391,6 +398,9 @@ class Model:
             bounds are provided on the fwhm for a line, the fwhm for
             this line will be fit to the data.
 
+        method : str
+            String to select fitting backend and algorithm (developer option)
+
         """
         # parse spectral data
         self.features.meta["user_unit"]["flux"] = spec.flux.unit
@@ -405,7 +415,7 @@ class Model:
         instrument.check_range([min(x), max(x)], inst)
 
         self._set_up_fitter(inst, z, lam=x, use_instrument_fwhm=use_instrument_fwhm)
-        self.fitter.fit(lam, flux, unc, maxiter=maxiter)
+        self.fitter.fit(lam, flux, unc, maxiter=maxiter, method=method)
 
         # copy the fit results to the features table
         self._ingest_fit_result_to_features()

--- a/pahfit/model.py
+++ b/pahfit/model.py
@@ -1,6 +1,7 @@
 from specutils import Spectrum1D
 from astropy import units as u
 from astropy import constants
+from astropy.table import vstack
 import copy
 import matplotlib as mpl
 from matplotlib import pyplot as plt
@@ -70,21 +71,23 @@ class Model:
         self.fit_info = None
 
     @classmethod
-    def from_yaml(cls, pack_file):
+    def from_yaml(cls, *pack_files):
         """
-        Generate feature table from YAML file.
+        Generate feature table from YAML file(s).
 
         Parameters
         ----------
-        pack_file : str
-            Path to YAML file, or name of one of the default YAML files.
+        pack_files : str, ...
+            Path to YAML file, or name of default YAML file. When more
+            than one is given, multiple packs will be combined. All
+            features in the given packs must have unique names.
 
         Returns
         -------
         Model instance
 
         """
-        features = Features.read(pack_file)
+        features = vstack([Features.read(pack_file) for pack_file in pack_files])
         return cls(features)
 
     @classmethod

--- a/pahfit/model.py
+++ b/pahfit/model.py
@@ -888,7 +888,10 @@ class Model:
 
             elif kind == "dust_continuum":
                 self.fitter.add_feature_dust_continuum(
-                    name, cleaned(row["temperature"]), cleaned(row["tau"])
+                    name,
+                    cleaned(row["temperature"]),
+                    cleaned(row["tau"]),
+                    model="special",
                 )
 
             elif kind == "line":

--- a/pahfit/model.py
+++ b/pahfit/model.py
@@ -231,7 +231,7 @@ class Model:
             bb = ModifiedBlackBody1D(1, temp)
             flux_ref = np.median(flux[(lam > lam_ref - 0.2) & (lam < lam_ref + 0.2)])
             amp_guess = flux_ref / bb(lam_ref)
-            return np.clip(amp_guess / nbb, 0, 1.)
+            return amp_guess / nbb        #np.clip(amp_guess / nbb, 0, 1.)
 
         loop_over_non_fixed("dust_continuum", "tau", dust_continuum_guess)
 

--- a/pahfit/model.py
+++ b/pahfit/model.py
@@ -891,7 +891,7 @@ class Model:
                     name,
                     cleaned(row["temperature"]),
                     cleaned(row["tau"]),
-                    model="special",
+                    model=row["model"],
                 )
 
             elif kind == "line":

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,6 +21,7 @@ install_requires =
     scipy
     matplotlib
     specutils
+    dust_extinction
 
 [options.extras_require]
 test =


### PR DESCRIPTION
There are still some loose ends since the publication of my paper (https://ui.adsabs.harvard.edu/abs/2025arXiv250705848V/abstract)

1. There are some additional features only available in my fork of PAHFIT. 
2. We have to add the PDR pack. I have made a clean version of it.

For now, to ensure reproducibility, I have created a snapshot of the code as it was used for the Orion Bar paper, in the form of a release under my fork: https://github.com/drvdputt/pahfit/releases/tag/OrionPaper2025.

I am submitting my branch as a pull request, so you can see the changes. We can decide which features we want to port over and clean it up, though it looks like it's not that much in terms of lines of code. 

The most notable parts, with some relevant issues linked:
1. Option to switch between dust continuum models, by providing the "model" keyword in the PDR pack. + The modified blackbody that I used in the paper, here called `SpecialModifiedBlackbody1D` #299 
2. Option to switch between fitting methods (different algorithms can be selected within APFitter). Currently this is done by passing down a keyword from the `Model.fit()` invocation. Options are `"lm"` and `"trf"` (Levenberg Marquardt vs Trust-Region Reflective). The `Fitter` subclass has a function to advertise the available options. Relevant for #149 
3. Different normalization for the blackbodies, addressing numerical precision issues. As discussed previously, we can consider changing the units of `tau` instead. (also: adjust initial guess for `tau`, as it was clipped between 0 and 1 previously). #296 
4. Option to pass multiple science packs when initializing a `Model`. Backwards compatible with a single science pack by using `*` for a variable number of arguments. #298 


