### PR TITLE
Fixed Model.fit metadata.

### DIFF
--- a/pahfit/model.py
+++ b/pahfit/model.py
@@ -398,8 +398,8 @@ class Model:
         x, _, _, lam, flux, unc = self._convert_spec_data(spec, z)
 
         # save these as part of the model (will be written to disk too)
-        self.features.meta["redshift"] = inst
-        self.features.meta["instrument"] = z
+        self.features.meta["redshift"] = z
+        self.features.meta["instrument"] = inst
 
         # check if observed spectrum is compatible with instrument model
         instrument.check_range([min(x), max(x)], inst)


### PR DESCRIPTION
In model.py (dev branch, lines 401–402; PR #308 branch, lines 425–426), 
the redshift and instrument metadata assignments are reversed after fitting:

    self.feat . ures.meta["redshift"] = inst   # stores instrument string
    self.features.meta["instrument"] = z    # stores float redshift

After model.fit(), meta["redshift"] holds the instrument name string 
and meta["instrument"] holds the float redshift value. This causes 
incorrect values to be saved and reloaded from ECSV files.

The correct assignments already exist earlier in the same file 
(dev branch lines 184–185), but fit() overwrites them with the 
swapped values on every call.