### PR TITLE
Add covariance uncertainty output helpers

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -53,15 +53,14 @@ Contributions welcome (see below).
 
 Contributors
 ------------
-* Dries van De Putte
 * J.D. Smith
+* Dries van De Putte
 * Karl Gordon
 * Thomas Lai
 * Alexandros Maragkoudakis
 * Els Peeters
 * Jan Cami
 * Ameek Sidhu
-* Dries Van De Putte
 
 License
 -------

--- a/pahfit/error_functions.py
+++ b/pahfit/error_functions.py
@@ -1,0 +1,251 @@
+#After running PAHFIT model.fit you can use 'model' as the input to pahfit_to_ecsv to save all fit params with associated errors from covariance 
+#matrices. The rest of the functions in here are just helper functions to make pahfit_to_ecsv work. -Hannah
+
+import numpy as np
+from astropy.table import Table
+
+
+def build_flat_name_map(astropy_model):
+    return {v: k for k, v in astropy_model._param_map.items()}
+def get_covariance(model, comp1, par1, comp2, par2):
+    astropy_model = model.fitter.model
+
+    flat_name_map = build_flat_name_map(astropy_model)
+
+    # component index
+    idx1 = astropy_model.submodel_names.index(comp1)
+    idx2 = astropy_model.submodel_names.index(comp2)
+
+    # map to flat names
+    flat1 = flat_name_map[(idx1, par1)]
+    flat2 = flat_name_map[(idx2, par2)]
+
+    return astropy_model.cov_matrix[flat1, flat2]
+def get_power_and_error(model, feature_name):
+    astropy_model = model.fitter.model
+
+    comp = astropy_model[feature_name]
+    power_val = comp.power.value
+
+    try:
+        var = get_covariance(model, feature_name, "power",
+                                   feature_name, "power")
+        power_err = np.sqrt(var)
+    except KeyError:
+        power_err = None
+
+    return {"power": power_val, "power_err": power_err}
+
+def pahfit_to_ecsv(model,
+                  output_file=None,
+                  include_components=None,
+                  exclude_components=None,
+                  include_params=None,
+                  add_metadata=True,
+                  verbose=False):
+    """
+    Extract PAHFIT model parameters + uncertainties from covariance matrix
+    and optionally save to an ECSV file.
+
+    Parameters
+    ----------
+    model : PAHFIT model object
+        The fitted PAHFIT model.
+
+    output_file : str, optional
+        Path to save ECSV file. If None, does not save.
+
+    include_components : list of str, optional
+        Only include these component names.
+
+    exclude_components : list of str, optional
+        Skip these component names.
+
+    include_params : list of str, optional
+        Only include these parameter names.
+
+    add_metadata : bool
+        Whether to include fit metadata (chi2, etc.)
+
+    verbose : bool
+        Print progress.
+
+    Returns
+    -------
+    table : astropy.table.Table
+    """
+
+    astropy_model = model.fitter.model
+
+    # ---- helper: map flattened covariance indices ----
+    def build_flat_name_map(astropy_model):
+        return {v: k for k, v in astropy_model._param_map.items()}
+
+    flat_name_map = build_flat_name_map(astropy_model)
+
+    def get_covariance(comp1, par1, comp2, par2):
+        try:
+            idx1 = astropy_model.submodel_names.index(comp1)
+            idx2 = astropy_model.submodel_names.index(comp2)
+
+            flat1 = flat_name_map[(idx1, par1)]
+            flat2 = flat_name_map[(idx2, par2)]
+
+            return astropy_model.cov_matrix[flat1, flat2]
+        except Exception:
+            return np.nan
+
+    def get_param_and_error(comp_name, param_name):
+        comp = astropy_model[comp_name]
+
+        try:
+            value = getattr(comp, param_name).value
+        except AttributeError:
+            return np.nan, np.nan
+
+        var = get_covariance(comp_name, param_name,
+                             comp_name, param_name)
+
+        if var is None or np.isnan(var) or var < 0:
+            err = np.nan
+        else:
+            err = np.sqrt(var)
+
+        return value, err
+
+    # ---- build table ----
+    rows = []
+
+    for comp_name in astropy_model.submodel_names:
+
+        # Apply filters
+        if include_components and comp_name not in include_components:
+            continue
+        if exclude_components and comp_name in exclude_components:
+            continue
+
+        comp = astropy_model[comp_name]
+
+        if not hasattr(comp, "param_names"):
+            continue
+
+        if verbose:
+            print(f"Processing {comp_name}")
+
+        row = {"feature": comp_name}
+
+        for param in comp.param_names:
+
+            if include_params and param not in include_params:
+                continue
+
+            val, err = get_param_and_error(comp_name, param)
+
+            row[param] = val
+            row[f"{param}_err"] = err
+
+        rows.append(row)
+
+    table = Table(rows)
+
+    # ---- add metadata ----
+    if add_metadata:
+        try:
+            table.meta["chi2"] = model.fit_info.get("chi2", np.nan)
+            table.meta["redchi"] = model.fit_info.get("redchi", np.nan)
+        except Exception:
+            pass
+
+    # ---- save if requested ----
+    if output_file is not None:
+        table.write(output_file, format="ascii.ecsv", overwrite=True)
+        if verbose:
+            print(f"Saved to {output_file}")
+
+    return table
+
+
+
+
+
+def covariance_to_table(model):
+    astropy_model = model.fitter.model
+    cov = astropy_model.cov_matrix
+
+    names = list(getattr(cov, "param_names", astropy_model.param_names))
+    cov_array = np.array(cov.cov_matrix if hasattr(cov, "cov_matrix") else cov, dtype=float)
+
+    table = Table(cov_array, names=names)
+    table.add_column(names, name="parameter", index=0)
+
+    return table
+
+def features_with_uncertainties(model, precision=6, include_covariance_meta=False):
+    param_unc_table = pahfit_to_ecsv(model)
+    final_features = model.features.copy()
+
+    for col in ["temperature_unc", "tau_unc", "power_unc", "wavelength_unc", "fwhm_unc"]:
+        if col not in final_features.colnames:
+            final_features[col] = np.full(len(final_features), np.nan)
+        else:
+            final_features[col][:] = np.nan
+
+    for col in ["temperature_pm", "tau_pm", "power_pm", "wavelength_pm", "fwhm_pm"]:
+        if col not in final_features.colnames:
+            final_features[col] = np.full(len(final_features), "", dtype="U64")
+        else:
+            final_features[col][:] = ""
+
+    def param_value(row, name):
+        try:
+            return float(row[name])
+        except Exception:
+            return np.nan
+
+    def pm_string(val, err):
+        if not np.isfinite(val):
+            return ""
+        if np.isfinite(err):
+            return f"{val:.{precision}g} ± {err:.{precision}g}"
+        return f"{val:.{precision}g}"
+
+    def assign(idx, pname, val, err):
+        final_features[f"{pname}_unc"][idx] = err
+        final_features[f"{pname}_pm"][idx] = pm_string(val, err)
+
+    for row in param_unc_table:
+        feature_name = str(row["feature"])
+        idx = np.where(final_features["name"] == feature_name)[0]
+        if len(idx) == 0:
+            continue
+
+        kind = str(final_features["kind"][idx[0]])
+
+        if kind in ("starlight", "dust_continuum"):
+            assign(idx, "temperature", param_value(row, "temperature"), param_value(row, "temperature_err"))
+            assign(idx, "tau", param_value(row, "amplitude"), param_value(row, "amplitude_err"))
+
+        elif kind == "line":
+            assign(idx, "power", param_value(row, "power"), param_value(row, "power_err"))
+            assign(idx, "wavelength", param_value(row, "mean"), param_value(row, "mean_err"))
+            assign(idx, "fwhm", 2.355 * param_value(row, "stddev"), 2.355 * param_value(row, "stddev_err"))
+
+        elif kind == "dust_feature":
+            assign(idx, "power", param_value(row, "power"), param_value(row, "power_err"))
+            assign(idx, "wavelength", param_value(row, "x_0"), param_value(row, "x_0_err"))
+            assign(idx, "fwhm", param_value(row, "fwhm"), param_value(row, "fwhm_err"))
+
+        elif kind == "attenuation":
+            assign(idx, "tau", param_value(row, "tau_sil"), param_value(row, "tau_sil_err"))
+
+        elif kind == "absorption":
+            assign(idx, "tau", param_value(row, "tau"), param_value(row, "tau_err"))
+            assign(idx, "wavelength", param_value(row, "x_0"), param_value(row, "x_0_err"))
+            assign(idx, "fwhm", param_value(row, "fwhm"), param_value(row, "fwhm_err"))
+
+    if include_covariance_meta:
+        cov = model.fitter.model.cov_matrix
+        final_features.meta["covariance_parameter_order"] = list(getattr(cov, "param_names", model.fitter.model.param_names))
+        final_features.meta["covariance_matrix"] = np.array(cov.cov_matrix if hasattr(cov, "cov_matrix") else cov, dtype=float).tolist()
+
+    return final_features

--- a/pahfit/features/features.py
+++ b/pahfit/features/features.py
@@ -349,7 +349,7 @@ class Features(Table):
             return
         if where is None:
             if keys:
-                where = np.zeros_like(self.colnames, dtype=np.bool)
+                where = np.zeros((len(self[param])), dtype=np.bool)
                 for k, v in keys.items():
                     if k in self.colnames:
                         col = self[k]

--- a/pahfit/features/features.py
+++ b/pahfit/features/features.py
@@ -301,7 +301,7 @@ class Features(Table):
 
     @staticmethod
     def _index_table(tbl):
-        for indx in ('name', 'group'):
+        for indx in ('name', 'group', 'kind'):
             tbl.add_index(indx)
 
     def mask_feature(self, name, mask_value=True):

--- a/pahfit/features/features.py
+++ b/pahfit/features/features.py
@@ -24,6 +24,7 @@ from astropy.io.misc.yaml import yaml
 from importlib import resources
 from pahfit.errors import PAHFITFeatureError
 from pahfit.features.features_format import BoundedParTableFormatter
+from pahfit.features.util import value_bounds
 import pahfit.units
 
 # Feature kinds and associated parameters
@@ -53,69 +54,6 @@ class UniqueKeyLoader(yaml.SafeLoader):
                 raise PAHFITFeatureError(f"Duplicate {key!r} key found in YAML.")
             mapping.add(key)
         return super().construct_mapping(node, deep)
-
-
-def value_bounds(val, bounds):
-    """Compute bounds for a bounded value.
-
-    Arguments:
-    ----------
-      val: The value to bound.
-
-      bounds: Either None for no relevant bounds (i.e. fixed), or a
-        two element iterable specifying (min, max) bounds.  Each of
-        min and max can be a numerical value, None (for infinite
-        bounds, either negative or positive, as appropriate), or a
-        string ending in:
-
-          #: an absolute offset from the value
-          %: a percentage offset from the value
-
-        Offsets are necessarily negative for min bound, positive for
-        max bounds.
-
-    Examples:
-    ---------
-
-      A bound of ('-1.5%', '0%') would indicate a minimum bound
-        1.5% below the value, and a max bound at the value itself.
-
-      A bound of ('-0.1#', None) would indicate a minimum bound 0.1 below
-        the value, and infinite maximum bound.
-
-    Returns:
-    -------
-
-      A 3 element tuple (value, min, max).
-        Any missing bound is replaced with the numpy.nan value.
-
-    Raises:
-    -------
-
-      ValueError: if bounds are specified and the value does not fall
-        between them.
-
-    """
-    if val is None:
-        val = np.ma.masked
-    if not bounds:
-        return (val,) + 2 * (np.nan,)  # (val,nan,nan) indicates fixed
-    ret = [val]
-    for i, b in enumerate(bounds):
-        if isinstance(b, str):
-            if b.endswith('%'):
-                b = val * (1. + float(b[:-1]) / 100.)
-            elif b.endswith('#'):
-                b = val + float(b[:-1])
-            else:
-                raise PAHFITFeatureError(f"Incorrectly formatted bound {b}")
-        elif b is None:
-            b = np.inf if i else -np.inf
-        ret.append(b)
-
-    if (val < ret[1] or val > ret[2]):
-        raise PAHFITFeatureError(f"Value <{ret[0]}> is not between bounds: {ret[1:]}")
-    return tuple(ret)
 
 
 class Features(Table):
@@ -360,8 +298,7 @@ class Features(Table):
     def mask_feature(self, name, mask_value=True):
         """Mask all the parameters of a feature.
 
-        The masks of the bounds are left intact, so we don't lose the
-        fixed / not fixed distinction.
+        The value is masked, but any bounds are left intact.
 
         This is used to indicate that the parameter values of this
         feature were not fit. This mask should not affect the model

--- a/pahfit/features/features.py
+++ b/pahfit/features/features.py
@@ -18,12 +18,14 @@ tables are therefore also available for pahfit.features.Features.
 """
 
 import os
+from warnings import warn
 from astropy.table.table import MaskedColumn
 import numpy as np
 from astropy.table import vstack, Table, TableAttribute
 from astropy.io.misc.yaml import yaml
 from importlib import resources
-from pahfit.errors import PAHFITFeatureError
+
+from pahfit.errors import PAHFITFeatureError, PAHFITWarning
 from pahfit.features.features_format import BoundedParTableFormatter
 from pahfit.features.util import value_bounds
 import pahfit.units
@@ -252,8 +254,9 @@ class Features(Table):
                                         else (*value_bounds(value, b), False))
             except ValueError as e:
                 raise PAHFITFeatureError("Error initializing value and bounds for"
-                                         f" {name} ({kind}, {group}):\n\t{e}")
+                                         f" {name} ({kind}, {group}):\n\t{e}") from e
 
+            
     @classmethod
     def _construct_table(cls, inp: dict):
         """Construct a masked table with units from input dictionary

--- a/pahfit/features/features.py
+++ b/pahfit/features/features.py
@@ -134,11 +134,14 @@ class Features(Table):
     TableFormatter = BoundedParTableFormatter
 
     param_covar = TableAttribute(default=[])
-    _group_attrs = set(('bounds', 'features', 'kind'))  # group-level attributes
-    _param_attrs = set(('value', 'bounds'))  # Each parameter can have these attributes
-    _no_bounds = set(('name', 'group', 'kind', 'geometry', 'model'))  # str attributes (no bounds)
+    _group_attrs = {'bounds', 'features', 'kind'}  # group-level attributes
+    _param_attrs = {'value', 'bounds'}  # Each parameter can have these attributes
+    _no_bounds = {'name', 'group', 'kind', 'geometry', 'model'}  # str attributes (no bounds)
     _bounds_dtype = np.dtype([("val", float), ("min", float), ("max", float)])  # bounded param type
+    _param_defaults = dict(geometry='mixed')
+    
 
+    
     @classmethod
     def read(cls, file, *args, **kwargs):
         """Read a table from file.
@@ -328,7 +331,10 @@ class Features(Table):
             for (name, params) in features.items():
                 for missing in kp - params.keys():
                     if missing in cls._no_bounds:
-                        params[missing] = 0.0
+                        if missing in cls._param_defaults:
+                            params[missing] = cls._param_defaults[missing]
+                        else:
+                            params[missing] = 0.0
                     else:
                         params[missing] = value_bounds(0.0, bounds=(0.0, None))
                 rows.append(dict(name=name, **params))

--- a/pahfit/features/features.py
+++ b/pahfit/features/features.py
@@ -32,8 +32,8 @@ import pahfit.units
 
 # Feature kinds and associated parameters
 KIND_PARAMS = {'starlight': {'temperature', 'tau'},
-               'dust_continuum': {'temperature', 'tau'},
-               'line': {'wavelength', 'power'},  # 'fwhm', Instrument Pack detail!
+               'dust_continuum': {'model', 'temperature', 'tau'},
+               'line': {'wavelength', 'fwhm', 'power'},  
                'dust_feature': {'wavelength', 'fwhm', 'power'},
                'attenuation': {'model', 'tau', 'geometry'},
                'absorption': {'wavelength', 'fwhm', 'tau', 'geometry'}}
@@ -82,7 +82,7 @@ class Features(Table):
                       'wavelength', 'fwhm', 'geometry', 'model'}
     _bounds_dtype = np.dtype([("val", float), ("min", float),  # bounded param type
                               ("max", float), ("frozen", bool)])
-    _param_defaults = dict(geometry='mixed')
+    _param_defaults = dict(geometry='mixed', model='kvt9')
 
     @classmethod
     def read(cls, file, *args, **kwargs):

--- a/pahfit/features/features_format.py
+++ b/pahfit/features/features_format.py
@@ -41,6 +41,6 @@ class BoundedParTableFormatter(TableFormatter):
             for col, fmt in bpcols:
                 col.info.format = fmt
 
-    def _name_and_structure(self, name, *args):
+    def _name_and_structure(self, name, *args, **kwargs):
         "Simplified column name: no val, min, max needed."
         return name

--- a/pahfit/features/features_format.py
+++ b/pahfit/features/features_format.py
@@ -1,5 +1,6 @@
 import numpy as np
 from astropy.table.pprint import TableFormatter
+from pahfit.features.util import bounded_is_fixed
 
 
 # * Special table formatting for bounded (val, min, max) values
@@ -9,9 +10,9 @@ def fmt_func(fmt: str):
         fmt = fmt[1:]
 
     def _fmt(x):
-        ret = f"{x['val']:{fmt}}"
-        if np.isnan(x['min']) and np.isnan(x['max']):
-            return ret + " (fixed)"
+        ret = f'{x["val"]:{fmt}}'
+        if bounded_is_fixed(x):
+            return f"{ret} ({'frz' if x['frozen'] else 'fxd'})"
         else:
             mn = ("-∞" if np.isnan(x['min']) or x['min'] == -np.inf
                   else f"{x['min']:{fmt}}")

--- a/pahfit/features/features_format.py
+++ b/pahfit/features/features_format.py
@@ -32,7 +32,7 @@ class BoundedParTableFormatter(TableFormatter):
         tlfmt = table.meta.get('pahfit_format')
         try:
             for col in table.columns.values():
-                if len(col.dtype) == 3:  # bounded!
+                if len(col.dtype) > 1:  # bounds!
                     bpcols.append((col, col.info.format))
                     fmt = col.meta.get('pahfit_format') or tlfmt or "g"
                     col.info.format = fmt_func(fmt)

--- a/pahfit/features/util.py
+++ b/pahfit/features/util.py
@@ -1,5 +1,69 @@
 """pahfit.util General pahfit.features utility functions."""
 import numpy as np
+from pahfit.errors import PAHFITFeatureError
+
+
+def value_bounds(val, bounds):
+    """Compute bounds for a bounded value.
+
+    Arguments:
+    ----------
+      val: The value to bound.
+
+      bounds: Either None for no relevant bounds (i.e. fixed), or a
+        two element iterable specifying (min, max) bounds.  Each of
+        min and max can be a numerical value, None (for infinite
+        bounds, either negative or positive, as appropriate), or a
+        string ending in:in
+
+          #: an absolute offset from the value
+          %: a percentage offset from the value
+
+        Offsets are necessarily negative for min bound, positive for
+        max bounds.
+
+    Examples:
+    ---------
+
+      A bound of ('-1.5%', '0%') would indicate a minimum bound
+        1.5% below the value, and a max bound at the value itself.
+
+      A bound of ('-0.1#', None) would indicate a minimum bound 0.1 below
+        the value, and infinite maximum bound.
+
+    Returns:
+    -------
+
+      A 3 element tuple (value, min, max).
+        Any missing bound is replaced with the numpy.nan value.
+
+    Raises:
+    -------
+
+      ValueError: if bounds are specified and the value does not fall
+        between them.
+
+    """
+    if val is None:
+        val = np.ma.masked
+    if not bounds:
+        return (val,) + 2 * (np.nan,)  # (val,nan,nan) indicates fixed
+    ret = [val]
+    for i, b in enumerate(bounds):
+        if isinstance(b, str):
+            if b.endswith('%'):
+                b = val * (1. + float(b[:-1]) / 100.)
+            elif b.endswith('#'):
+                b = val + float(b[:-1])
+            else:
+                raise PAHFITFeatureError(f"Incorrectly formatted bound {b}")
+        elif b is None:
+            b = np.inf if i else -np.inf
+        ret.append(b)
+
+    if (val < ret[1] or val > ret[2]):
+        raise PAHFITFeatureError(f"Value <{ret[0]}> is not between bounds: {ret[1:]}")
+    return tuple(ret)
 
 
 def bounded_is_missing(val):

--- a/pahfit/features/util.py
+++ b/pahfit/features/util.py
@@ -1,6 +1,6 @@
 """pahfit.util General pahfit.features utility functions."""
 import numpy as np
-from pahfit.errors import PAHFITFeatureError
+from pahfit.errors import PAHFITFeatureError, PAHFITModelError, PAHFITWarning
 
 
 def value_bounds(val, bounds):

--- a/pahfit/features/util.py
+++ b/pahfit/features/util.py
@@ -66,10 +66,10 @@ def value_bounds(val, bounds):
     return tuple(ret)
 
 
-def bounded_is_missing(val):
+def bounded_is_disabled(vals):
     """Return a mask array indicating which of the bounded values
-    are missing.  A missing bounded value has a masked value."""
-    return getattr(val['val'], 'mask', None) or np.zeros_like(val['val'], dtype=bool)
+    are disabled.  A disabled bounded value has a masked value."""
+    return vals['val'].mask
 
 
 def bounded_is_fixed(vals):

--- a/pahfit/features/util.py
+++ b/pahfit/features/util.py
@@ -72,10 +72,20 @@ def bounded_is_missing(val):
     return getattr(val['val'], 'mask', None) or np.zeros_like(val['val'], dtype=bool)
 
 
-def bounded_is_fixed(val):
-    """Return a mask array indicating which of the bounded values
-    are fixed.  A fixed bounded value has masked bounds."""
-    return np.isnan(val['min']) & np.isnan(val['max'])
+def bounded_is_fixed(vals):
+    """Return a boolean or boolean array indicating which of the
+    bounded values are fixed.  A fixed bounded value has both its
+    bounds either set to nan.
+
+    Note that masked values in `vals` are considered disabled, not
+    fixed.  If the provided `vals` have no bounds fields, a False
+    array is returned.
+    """
+    if (names := vals.dtype.names) and 'max' in names:
+        return (vals['frozen'] |
+                (np.isnan(vals['min'].data) & np.isnan(vals['max'].data)))
+    else:
+        return np.zeros(vals.shape, dtype=np.bool)
 
 
 def bounded_min(val):

--- a/pahfit/fitters/__init__.py
+++ b/pahfit/fitters/__init__.py
@@ -1,0 +1,2 @@
+from .fitter import Fitter
+from .ap_fitter import APFitter

--- a/pahfit/fitters/ap_components.py
+++ b/pahfit/fitters/ap_components.py
@@ -25,9 +25,9 @@ class BlackBody1D(Fittable1DModel):
         """ """
         return (
             amplitude
-            * 3.97289e13
-            / x**3
-            / (np.exp(1.4387752e4 / x / temperature) - 1.0)
+            * 3.9728917e13 # 2 h c/µm^3 -> MJy
+            / x**3 
+            / (np.exp(1.4387752e4 / x / temperature) - 1.0)  # h c/micron k K
         )
 
 

--- a/pahfit/fitters/ap_components.py
+++ b/pahfit/fitters/ap_components.py
@@ -5,8 +5,23 @@ from astropy.modeling import Fittable1DModel
 from astropy.modeling import Parameter
 from astropy import constants
 from pahfit import units
+from dust_extinction.parameter_averages import G23
+from astropy import units as u
 
-__all__ = ["BlackBody1D", "ModifiedBlackBody1D", "S07_attenuation", "att_Drude1D"]
+__all__ = ["BlackBody1D", 
+           "ModifiedBlackBody1D", 
+           "S07_attenuation", 
+           "att_Drude1D", 
+           "PowerDrude1D",
+           "PowerGaussian1D"]
+
+
+def bb(x, temperature):
+    return (
+        3.9728917e13  # 2 h c/µm^3 -> MJy
+        / x**3
+        / (np.exp(1.4387752e4 / x / temperature) - 1.0)
+    )  # h c/micron k K
 
 
 class BlackBody1D(Fittable1DModel):
@@ -20,15 +35,13 @@ class BlackBody1D(Fittable1DModel):
     amplitude = Parameter()
     temperature = Parameter()
 
+    norm = bb(3, 5000)
+    print("norm for bb is", norm)
+
     @staticmethod
     def evaluate(x, amplitude, temperature):
         """ """
-        return (
-            amplitude
-            * 3.9728917e13 # 2 h c/µm^3 -> MJy
-            / x**3 
-            / (np.exp(1.4387752e4 / x / temperature) - 1.0)  # h c/micron k K
-        )
+        return amplitude * bb(x, temperature) / BlackBody1D.norm
 
 
 class ModifiedBlackBody1D(BlackBody1D):
@@ -38,7 +51,9 @@ class ModifiedBlackBody1D(BlackBody1D):
 
     @staticmethod
     def evaluate(x, amplitude, temperature):
-        return BlackBody1D.evaluate(x, amplitude, temperature) * ((9.7 / x) ** 2)
+        bb = BlackBody1D.evaluate(x, 1, temperature) * ((9.7 / x) ** 2)
+        bb_ref = BlackBody1D.evaluate(17, 1, temperature) * ((9.7 / 17) ** 2)
+        return amplitude * bb / bb_ref
 
 
 class S07_attenuation(Fittable1DModel):
@@ -223,7 +238,6 @@ class PowerDrude1D(Fittable1DModel):
         g = fwhm / x_0
         b = power * x_0 / g * self.intensity_amplitude_factor
         return b * g**2 / ((x / x_0 - x_0 / x) ** 2 + g**2)
-
 
 class PowerGaussian1D(Fittable1DModel):
     """

--- a/pahfit/fitters/ap_fitter.py
+++ b/pahfit/fitters/ap_fitter.py
@@ -13,7 +13,8 @@ import numpy as np
 
 
 class APFitter(Fitter):
-    """Astropy fitting implementation using Fitter API.
+    """Astropy fitting implementation using
+    :class:`pahfit.fitters.Fitter` API.
 
     Fitter API is still subject to change. This draft was written with
     what is needed, and the Fitter class was set up based on this draft.
@@ -54,7 +55,6 @@ class APFitter(Fitter):
     - Use the 'tied' option for parameters that should be equivalent
       (e.g. starlight in segment 1 should have same temperature as
       starlight in segment 2).
-
     """
 
     def __init__(self):

--- a/pahfit/fitters/ap_fitter.py
+++ b/pahfit/fitters/ap_fitter.py
@@ -1,6 +1,6 @@
-from pahfit.fitters.fitter import Fitter
+from . import Fitter
 from pahfit.errors import PAHFITModelError
-from pahfit.fitters.ap_components import (
+from .ap_components import (
     BlackBody1D,
     ModifiedBlackBody1D,
     S07_attenuation,

--- a/pahfit/fitters/ap_fitter.py
+++ b/pahfit/fitters/ap_fitter.py
@@ -6,9 +6,8 @@ from .ap_components import (
     S07_attenuation,
     att_Drude1D,
     PowerDrude1D,
-    PowerGaussian1D,
-)
-from astropy.modeling.fitting import LevMarLSQFitter
+    PowerGaussian1D)
+from astropy.modeling.fitting import LevMarLSQFitter, TRFLSQFitter
 import numpy as np
 
 
@@ -69,6 +68,7 @@ class APFitter(Fitter):
         self.feature_types = {}
         self.model = None
         self.message = None
+        self.methods = ["lm", "trf"]
 
     def finalize(self):
         """Sum the registered components into one CompoundModel.
@@ -137,18 +137,26 @@ class APFitter(Fitter):
         )
         self._add_component(BlackBody1D, **kwargs)
 
-    def add_feature_dust_continuum(self, name, temperature, tau):
+    def add_feature_dust_continuum(self, name, temperature, tau, model="default"):
         """Register a ModifiedBlackBody1D.
 
         Analogous. Temperature and tau are used as temperature and
         amplitude
 
+        Parameters
+        ----------
+        model : str (available values: 'default' and 'special')
+            Keyword to activate alternate continuum shapes. 'default' is
+            a modified blackbody with a lambda**-2 factor. With
+            model='special', the modification factor is the MW average
+            extinction law for Rv=5.5.
+
         """
         self.feature_types[name] = "dust_continuum"
         kwargs = self._astropy_model_kwargs(
-            name, ["temperature", "amplitude"], [temperature, tau]
-        )
-        self._add_component(ModifiedBlackBody1D, **kwargs)
+            name, ["temperature", "amplitude"], [temperature, tau])
+        ap_class = ModifiedBlackBody1D
+        self._add_component(ap_class, **kwargs)
 
     def add_feature_line(self, name, power, wavelength, fwhm):
         """Register a PowerGaussian1D
@@ -202,10 +210,9 @@ class APFitter(Fitter):
 
         """
         self.feature_types[name] = "absorption"
-        kwargs = self._astropy_model_kwargs(
-            name, ["tau", "x_0", "fwhm"], [tau, wavelength, fwhm]
-        )
+        kwargs = self._astropy_model_kwargs(name, ["tau", "x_0", "fwhm"], [tau, wavelength, fwhm])
         self._add_component(att_Drude1D, multiplicative=True, **kwargs)
+
 
     def evaluate(self, lam):
         """Evaluate internal astropy model with its current parameters.
@@ -222,7 +229,10 @@ class APFitter(Fitter):
         """
         return self.model(lam)
 
-    def fit(self, lam, flux, unc, maxiter=10000):
+    def fit_methods_available(self):
+        return self.methods
+
+    def fit(self, lam, flux, unc, maxiter=10000, method=None):
         """Fit the internal model using the astropy fitter.
 
         The fitter class is unit agnostic, and deal with the numbers the
@@ -254,6 +264,10 @@ class APFitter(Fitter):
         unc : array
             Uncertainty on rest frame flux. Same units as flux.
 
+        method : str
+            Fit method. Available options: "lm" will use
+            LevMarLSQFitter. "trf" will use TRFLSQFitter.
+
         """
         # clean, because astropy does not like nan
         w = 1 / unc
@@ -263,19 +277,35 @@ class APFitter(Fitter):
 
         self.fit_info = []
 
-        fit = LevMarLSQFitter(calc_uncertainties=True)
-        astropy_result = fit(
+        # select method based on given string or pick default if None
+        method_str = self.methods[0] if method is None else method
+        if method_str not in self.methods:
+            PAHFITModelError(
+                f"Selected method {method} not available for APFitter backend."
+            )
+
+        fitter_call_kwargs = dict(acc=1e-10)
+        if method_str == "lm":
+            fitter_cls = LevMarLSQFitter
+        elif method_str == "trf":
+            fitter_cls = TRFLSQFitter
+            fitter_call_kwargs["acc"] = 1e-15
+
+        print(f"Running {method_str}lsq fit")
+        fit = fitter_cls(calc_uncertainties=True)
+        temp_result = fit(
             self.model,
             lam[mask],
             flux[mask],
             weights=w[mask],
             maxiter=maxiter,
             epsilon=1e-10,
-            acc=1e-10,
+            **fitter_call_kwargs,
         )
+
         self.fit_info = fit.fit_info
-        self.model = astropy_result
         self.message = fit.fit_info["message"]
+        self.model = temp_result
 
     def get_result(self, component_name):
         """Retrieve results from astropy model component.
@@ -315,28 +345,24 @@ class APFitter(Fitter):
         if c_type == "starlight" or c_type == "dust_continuum":
             return {
                 "temperature": component.temperature.value,
-                "tau": component.amplitude.value,
-            }
+                "tau": component.amplitude.value}
         elif c_type == "line":
             return {
                 "power": component.power.value,
                 "wavelength": component.mean.value,
-                "fwhm": component.stddev.value * 2.355,
-            }
-        elif c_type == "dust_feature":
+                "fwhm": component.stddev.value * 2.355}
+        elif c_type in "dust_feature":
             return {
                 "power": component.power.value,
                 "wavelength": component.x_0.value,
-                "fwhm": component.fwhm.value,
-            }
+                "fwhm": component.fwhm.value}
         elif c_type == "attenuation":
             return {"tau": component.tau_sil.value}
         elif c_type == "absorption":
             return {
                 "tau": component.tau.value,
                 "wavelength": component.x_0.value,
-                "fwhm": component.fwhm.value,
-            }
+                "fwhm": component.fwhm.value}
         else:
             raise PAHFITModelError(f"Unsupported component type: {c_type}")
 

--- a/pahfit/fitters/fitter.py
+++ b/pahfit/fitters/fitter.py
@@ -2,7 +2,7 @@ from abc import ABC, abstractmethod
 
 
 class Fitter(ABC):
-    """Abstract base class for interal Fitter API.
+    """Abstract base class for internal Fitter API.
 
     All shared methods should have the same arguments, enforced by this
     abstract class. Any API-specific options preferably go into the
@@ -10,16 +10,20 @@ class Fitter(ABC):
     dictionaries could also be used if absolutely necessary.
 
     The main functionalities of a Fitter subclass:
+
     1. Convert the numbers that are in the Features table to a fittable
        model configuration for a certain framework. The details of the
        fitting framework are hidden behind the respective subclass.
-    2. Fit the model to the spectrum without any additional assumptions.
-       The Fitter will fit the given data using the given model without
-       thinking about redshift, units, instrumental effects.
+
+    2. Fit the model to the spectrum without any additional
+       assumptions.  The Fitter will fit the given data using the
+       given model without needing to be aware of redshift, units, or
+       other instrumental effects.
+    
     3. Retrieve the fitted quantities, which are the values that were
-       passed during step 1. When fit result uncertainties are
-       implemented, they will also need to be retrieved through this
-       API.
+       passed during step 1.  When fit uncertainties are implemented,
+       they will also need to be retrieved through this API.
+
     4. Access to the evaluation of the underlying model (again with no
        assumptions like in step 2.).
 
@@ -27,23 +31,25 @@ class Fitter(ABC):
 
     For the model setup, there is one function per type of component
     supported by PAHFIT, and the arguments of these functions will ask
-    for certain standard PAHFIT quantities (in practice, these are the
-    values stored in the Features table). The abstract Fitter class
-    ensure that the function signatures are the same between different
-    Fitter implementations, so that only a single logic has to be
-    implemented to up the Fitter (in practice, this is a loop over the
-    Features table implemented in Model).
+    for certain standard parameters (in practice, these are the values
+    stored in the Features table). This abstract Fitter class ensures
+    that the function signatures are the same between different Fitter
+    implementations, so that uniform logic can be implemented outside
+    of the Fitter (in practice, this is a loop over the Features table
+    implemented in :class:`pahfit.model.Model`).
 
     During the Fitter setup, the initial values, bounds, and "fixed"
     flags are passed using one function call for each component, e.g.
-    add_feature_line()). Once all components have been added, the
-    finalize() function should be called; some subclasses (e.g.
-    APFitter) need to consolidate the registered components to prepare
-    the model that they manage for fitting. After this, fit() can be
-    called to apply the model and the astropy fitter to the data. The
-    results will then be retrievable for one component at a time, by
-    passing the component name to get_result().
-
+    :meth:`~pahfit.fitters.Fitter.add_feature_line`.  Once all
+    components have been added, the
+    :meth:`~pahfit.fitters.Fitter.finalize` function should be called;
+    some subclasses (e.g. :class:`pahfit.fitters.APFitter`) need to
+    consolidate the registered components to prepare the model that
+    they manage for fitting. After this,
+    :meth:`~pahfit.fitters.Fitter.fit` can be called to apply the
+    model and the fitter to the data. The results will then be
+    retrievable for one component at a time, by passing the component
+    name to get_result().
     """
 
     @abstractmethod
@@ -109,9 +115,8 @@ class Fitter(ABC):
     def add_feature_attenuation(self, name, tau, model="S07", geometry="screen"):
         """Register the S07 attenuation component.
 
-        Other types of attenuation might be possible in the future. Is
-        multiplicative.
-
+        Other types of attenuation might be possible in the
+        future. Multiplicative.
         """
         pass
 
@@ -119,7 +124,7 @@ class Fitter(ABC):
     def add_feature_absorption(self, name, tau, wavelength, fwhm, geometry="screen"):
         """Register an absorption feature.
 
-        Modeled by a Drude profile. Is multiplicative.
+        Modeled by a Drude profile.  Multiplicative.
 
         """
         pass
@@ -145,45 +150,48 @@ class Fitter(ABC):
     def fit(self, lam, flux, unc, maxiter=1000):
         """Perform the fit using the framework of the subclass.
 
-        Fitter is unit agnostic, and deals with the numbers the Model
-        tells it to deal with. In practice, the input spectrum is
-        expected to be in internal units, and corrected for redshift
-        (models operate in the rest frame).
+        :class:`~pahfit.fitters.Fitter` is unit agnostic, and deals
+        with the numbers the :class:`~pahfit.model.Model` tells it to
+        deal with.  In practice, the input spectrum should be expected
+        in internal units (see :mod:`pahfit.units`), and corrected for
+        redshift (models operate in the rest frame).
 
         After the fit, the results can be retrieved via get_result().
 
         Parameters
         ----------
         lam : array
-            Rest frame wavelengths in micron
+            Rest frame wavelengths in microns.
 
         flux : array
             Rest frame flux in internal units.
 
         unc : array
-            Uncertainty on rest frame flux. Same units as flux.
-
+            Uncertainty in the rest-frame flux.  Same units as flux.
         """
         pass
 
     @abstractmethod
     def get_result(self, feature_name):
-        """Retrieve results from underlying model after fit.
+        """Retrieve results from the underlying model after fit.
 
         Parameters
         ----------
         component_name : str
-            One of the names provided to any of the add_feature_() calls
-            made during setup.
+            One of the names provided to any of the
+            :meth:`~pahfit.fitters.Fitter.add_feature` calls made
+            during setup.
 
         Returns
         -------
-        dict : parameters according to the PAHFIT definitions. Keys are
-        the same as the function signature of the relevant register
-        function. Values are in the same format as Features, and can
-        therefore be directly filled in.
+        feature_info : dict
+           feature parameters according to the relevant PAHFIT
+           definitions. Key names are the same as the function
+           arguments of the relevant register function. Values are in
+           the same format as :class:`~pahfit.feature.Features`, and
+           can therefore be directly filled in.
 
-        e.g. {'name': 'line0', 'power': value, 'fwhm': value, 'wavelength': value}
-
+           E.g. ``{'name': 'line0', 'power': value, 'fwhm': value,
+        'wavelength': value}``.
         """
         pass

--- a/pahfit/fitters/fitter.py
+++ b/pahfit/fitters/fitter.py
@@ -94,15 +94,6 @@ class Fitter(ABC):
         pass
 
     @abstractmethod
-    def add_feature_line(self, name, power, wavelength, fwhm):
-        """Register an emission line feature.
-
-        Typically a Gaussian profile.
-
-        """
-        pass
-
-    @abstractmethod
     def add_feature_dust_feature(self, name, power, wavelength, fwhm):
         """Register a dust feature.
 
@@ -147,7 +138,11 @@ class Fitter(ABC):
         pass
 
     @abstractmethod
-    def fit(self, lam, flux, unc, maxiter=1000):
+    def fit_methods_available(self):
+        return [None]
+
+    @abstractmethod
+    def fit(self, lam, flux, unc, maxiter=1000, method=None):
         """Perform the fit using the framework of the subclass.
 
         :class:`~pahfit.fitters.Fitter` is unit agnostic, and deals
@@ -168,6 +163,11 @@ class Fitter(ABC):
 
         unc : array
             Uncertainty in the rest-frame flux.  Same units as flux.
+
+        method : str
+            Override fit method. Available options are returned by
+            fit_methods_available, of which the output depends on the
+            subclass.
         """
         pass
 

--- a/pahfit/instrument.py
+++ b/pahfit/instrument.py
@@ -34,8 +34,7 @@ def read_instrument_packs():
                 "Error reading instrument pack file\n" f"\t{pack}\n\t{repr(e)}"
             )
         else:
-            telescope = os.path.basename(pack).rstrip(".yaml")
-            packs[telescope] = p
+            packs[pack.stem] = p
     packs = dict(_ins_items("", packs))  # Flatten list
 
 

--- a/pahfit/instrument.py
+++ b/pahfit/instrument.py
@@ -24,6 +24,7 @@ packs = {}
 def read_instrument_packs():
     """Read all instrument packs into the 'packs' variable."""
     global packs
+    packs = {}
     for pack in (resources.files("pahfit") / "packs/instrument").glob("*.yaml"):
         try:
             with open(pack) as fd:

--- a/pahfit/model.py
+++ b/pahfit/model.py
@@ -447,10 +447,8 @@ class Model:
                     else:
                         self.features[column][i] = (value, np.nan, np.nan)
                 except Exception as e:
-                    print(
-                        f"Could not assign to name {name} in features table. Some diagnostic output below"
-                    )
-                    print(f"Index i is {i}")
+                    print(f"Could not assign to attribute {name} in features table.")
+                    print(f"Index {i=}")
                     print("Features table:", self.features)
                     raise e
 

--- a/pahfit/model.py
+++ b/pahfit/model.py
@@ -877,13 +877,13 @@ class Model:
         excluded = self._excluded_features(instrumentname, redshift, lam)
         self.enabled_features = self.features["name"][~excluded]
 
-        def cleaned(features_tuple3):
-            val = features_tuple3[0]
-            if bounded_is_fixed(features_tuple3):
+        def cleaned(value):
+            val = value['val']
+            if bounded_is_fixed(value):
                 return val
             else:
-                vmin = -np.inf if np.isnan(features_tuple3[1]) else features_tuple3[1]
-                vmax = np.inf if np.isnan(features_tuple3[2]) else features_tuple3[2]
+                vmin = -np.inf if np.isnan(value['min']) else value['min']
+                vmax = np.inf if np.isnan(value['max']) else value['max']
                 return np.array([val, vmin, vmax])
 
         for row in self.features[~excluded]:

--- a/pahfit/model.py
+++ b/pahfit/model.py
@@ -501,15 +501,17 @@ class Model:
         inst, z = self._parse_instrument_and_redshift(spec, redshift)
         _, _, _, lam, flux, unc = self._convert_spec_data(spec, z)
         enough_samples = max(10000, len(spec.wavelength))
-        lam_mod = np.logspace(np.log10(min(lam)), np.log10(max(lam)), enough_samples)
+        mnlam, mxlam = min(lam), max(lam)
+        lam_mod = np.logspace(np.log10(mnlam), np.log10(mxlam), enough_samples)
 
-        fig, axs = plt.subplots(ncols=1, nrows=2, figsize=(10, 10),
+        fig, axs = plt.subplots(ncols=1, nrows=2, figsize=(10, 7),
                                 gridspec_kw={"height_ratios": [3, 1]}, sharex=True, **kwargs)
 
         # spectrum and best fit model
         ax = axs[0]
         ax.set_yscale("linear")
         ax.set_xscale("log")
+        ax.get_xaxis().set_major_formatter(mpl.ticker.ScalarFormatter())
         ax.minorticks_on()
         ax.tick_params(axis="both", which="major", top="on", right="on",
                        direction="in", length=10)
@@ -656,12 +658,6 @@ class Model:
         ax.tick_params(axis="both", which="minor", top="on", right="on",
                        direction="in", length=5)
         ax.minorticks_on()
-
-        # Custom X axis ticks
-        ax.xaxis.set_ticks(
-            [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12, 14, 16, 20, 25, 30, 40]
-        )
-
         ax.axhline(0, linestyle="--", color="gray", zorder=0)
         ax.plot(
             lam,
@@ -674,13 +670,14 @@ class Model:
             linestyle="none",
         )
         ax.set_ylim(-scalefac_resid * std, scalefac_resid * std)
-        ax.set_xlim(np.floor(np.amin(lam)), np.ceil(np.amax(lam)))
         ax.set_xlabel(r"$\lambda$ [$\mu m$]")
         ax.set_ylabel("Residuals [%]")
 
-        # scalar x-axis marks
-        ax.xaxis.set_major_formatter(mpl.ticker.ScalarFormatter())
+        # Refine x-axis
+        ax.set_xlim(mnlam, mxlam)
+        ax.xaxis.set_minor_formatter(mpl.ticker.ScalarFormatter())
         fig.subplots_adjust(hspace=0)
+        fig.tight_layout()
         return fig
 
     def copy(self):

--- a/pahfit/model.py
+++ b/pahfit/model.py
@@ -138,13 +138,8 @@ class Model:
     def _repr_html_(self):
         return self._status_message() + self.features._repr_html_()
 
-    def guess(
-        self,
-        spec: Spectrum1D,
-        redshift=None,
-        integrate_line_flux=False,
-        calc_line_fwhm=True,
-    ):
+    def guess(self, spec: Spectrum1D, redshift=None, integrate_line_flux=False,
+              calc_line_fwhm=True):
         """Make an initial guess of the physics, based on the given
         observational data.
 

--- a/pahfit/model.py
+++ b/pahfit/model.py
@@ -342,14 +342,8 @@ class Model:
         unc = unc_obs * (1 + z)  # uncertainty scales with flux
         return lam_obs, flux_obs, unc_obs, lam, flux, unc
 
-    def fit(
-        self,
-        spec: Spectrum1D,
-        redshift=None,
-        maxiter=1000,
-        verbose=True,
-        use_instrument_fwhm=True,
-    ):
+    def fit(self, spec: Spectrum1D, redshift=None, maxiter=1000, verbose=True,
+            use_instrument_fwhm=True):
         """Fit the observed data.
 
         The model setup is based on the features table and instrument
@@ -830,9 +824,8 @@ class Model:
 
         return is_outside & is_excludable
 
-    def _set_up_fitter(
-        self, instrumentname, redshift, lam=None, use_instrument_fwhm=True
-    ):
+    def _set_up_fitter(self, instrumentname, redshift, lam=None,
+                       use_instrument_fwhm=True):
         """Convert features table to Fitter instance, set self.fitter.
 
         For every row of the features table, calls a function of Fitter

--- a/pahfit/model.py
+++ b/pahfit/model.py
@@ -532,8 +532,7 @@ class Model:
 
         ax.errorbar(lam, flux, yerr=unc, **(default_kwargs | errorbar_kwargs))
         ax.set_ylim(0)
-        ax.set_ylabel(r"$F_{\nu}$")
-
+        ax.set_ylabel(r"$I_{\nu}$ " + f"({sp_unit})")
         ax.get_xaxis().set_major_formatter(mpl.ticker.ScalarFormatter())
         ax.minorticks_on()
         ax.tick_params(axis="both", which="major", top="on", right="on",
@@ -664,7 +663,7 @@ class Model:
                 linestyle="none")
         ax.set_ylim(-scalefac_resid * std, scalefac_resid * std)
         ax.set_xlabel(r"$\lambda$ [$\mu m$]")
-        ax.set_ylabel("Residuals [%]")
+        ax.set_ylabel(f"Residuals ({sp_unit})")
 
         # Refine x-axis
         ax.set_xlim(mnlam, mxlam)

--- a/pahfit/model.py
+++ b/pahfit/model.py
@@ -8,7 +8,7 @@ import numpy as np
 from scipy import interpolate, integrate
 
 from pahfit import units
-from pahfit.features.util import bounded_is_fixed, bounded_is_missing
+from pahfit.features.util import bounded_is_fixed, bounded_is_disabled
 from pahfit.features import Features
 from pahfit import instrument
 from pahfit.errors import PAHFITModelError
@@ -441,8 +441,8 @@ class Model:
             for column, value in self.fitter.get_result(name).items():
                 try:
                     i = np.where(self.features["name"] == name)[0]
-                    # deal with fwhm usually being masked
-                    if not bounded_is_missing(self.features[column][i]):
+                    # do not update disabled attributes (e.g. line fwhm is usually masked)
+                    if not bounded_is_disabled(self.features[column][i]):
                         self.features[column]["val"][i] = value
                     else:
                         self.features[column][i] = (value, np.nan, np.nan)

--- a/pahfit/model.py
+++ b/pahfit/model.py
@@ -511,15 +511,29 @@ class Model:
         ax = axs[0]
         ax.set_yscale("linear")
         ax.set_xscale("log")
+
+        plot_kwargs = plot_kwargs or {}
+        errorbar_kwargs = errorbar_kwargs or {}
+        default_kwargs = dict(
+            fmt="o",
+            markeredgecolor="k",
+            markerfacecolor="none",
+            ecolor="k",
+            elinewidth=0.2,
+            capsize=0.5,
+            markersize=4,
+        )
+
+        ax.errorbar(lam, flux, yerr=unc, **(default_kwargs | errorbar_kwargs))
+        ax.set_ylim(0)
+        ax.set_ylabel(r"$F_{\nu}$")
+
         ax.get_xaxis().set_major_formatter(mpl.ticker.ScalarFormatter())
         ax.minorticks_on()
         ax.tick_params(axis="both", which="major", top="on", right="on",
                        direction="in", length=10)
         ax.tick_params(axis="both", which="minor", top="on", right="on",
                        direction="in", length=5)
-
-        plot_kwargs = plot_kwargs or {}
-        errorbar_kwargs = errorbar_kwargs or {}
 
         ext_model = None
         has_att = "attenuation" in self.features["kind"]
@@ -546,7 +560,7 @@ class Model:
             ax_att.tick_params(which="minor", direction="in", length=5)
             ax_att.tick_params(which="major", direction="in", length=10)
             ax_att.minorticks_on()
-            ax_att.plot(lam_mod, ext_model, "k--", alpha=0.5, **plot_kwargs)
+            ax_att.plot(lam_mod, ext_model, "k--", alpha=0.7, **plot_kwargs)
             ax_att.set_ylabel("Attenuation")
             ax_att.set_ylim(0, 1.1)
         else:
@@ -556,10 +570,10 @@ class Model:
         Leg_lines = [
             mpl.lines.Line2D([0], [0], color="k", linestyle="--", lw=2),
             mpl.lines.Line2D([0], [0], color="#FE6100", lw=2),
-            mpl.lines.Line2D([0], [0], color="#648FFF", lw=2, alpha=0.5),
-            mpl.lines.Line2D([0], [0], color="#DC267F", lw=2, alpha=0.5),
+            mpl.lines.Line2D([0], [0], color="#648FFF", lw=2, alpha=0.7),
+            mpl.lines.Line2D([0], [0], color="#DC267F", lw=2, alpha=0.7),
             mpl.lines.Line2D([0], [0], color="#785EF0", lw=2, alpha=1),
-            mpl.lines.Line2D([0], [0], color="#FFB000", lw=2, alpha=0.5),
+            mpl.lines.Line2D([0], [0], color="#FFB000", lw=2, alpha=0.7),
         ]
 
         # local utility
@@ -574,7 +588,7 @@ class Model:
         if "dust_continuum" in self.features["kind"]:
             # one plot for every component
             for y in tabulate_components("dust_continuum").values():
-                ax.plot(lam_mod, y * ext_model, "#FFB000", alpha=0.5, **plot_kwargs)
+                ax.plot(lam_mod, y * ext_model, "#FFB000", alpha=0.7, **plot_kwargs)
                 # keep track of total continuum
                 cont_y += y
 
@@ -582,7 +596,7 @@ class Model:
             star_y = self.tabulate(
                 inst, z, lam_mod, self.features["kind"] == "starlight"
             ).flux.value
-            ax.plot(lam_mod, star_y * ext_model, "#ffB000", alpha=0.5, **plot_kwargs)
+            ax.plot(lam_mod, star_y * ext_model, "#ffB000", alpha=0.7, **plot_kwargs)
             cont_y += star_y
 
         # total continuum
@@ -595,13 +609,13 @@ class Model:
                     lam_mod,
                     (cont_y + y) * ext_model,
                     "#648FFF",
-                    alpha=0.5, **plot_kwargs
+                    alpha=0.7, **plot_kwargs
                 )
 
         if "line" in self.features["kind"]:
             for name, y in tabulate_components("line").items():
                 ax.plot(lam_mod, (cont_y + y) * ext_model, "#DC267F",
-                        alpha=0.5, **plot_kwargs)
+                        alpha=0.7, **plot_kwargs)
                 if label_lines:
                     i = np.argmax(y)
                     # ignore out of range lines
@@ -612,22 +626,6 @@ class Model:
                                 bbox=dict(facecolor="white", alpha=0.75, pad=0))
 
         ax.plot(lam_mod, self.tabulate(inst, z, lam_mod).flux.value, "#FE6100", alpha=1)
-
-        # data
-        default_kwargs = dict(
-            fmt="o",
-            markeredgecolor="k",
-            markerfacecolor="none",
-            ecolor="k",
-            elinewidth=0.2,
-            capsize=0.5,
-            markersize=6,
-        )
-
-        ax.errorbar(lam, flux, yerr=unc, **(default_kwargs | errorbar_kwargs))
-
-        ax.set_ylim(0)
-        ax.set_ylabel(r"$\nu F_{\nu}$")
 
         ax.legend(
             Leg_lines,

--- a/pahfit/model.py
+++ b/pahfit/model.py
@@ -1,6 +1,7 @@
 from specutils import Spectrum1D
 from astropy import units as u
 from astropy import constants
+from astropy.table import vstack
 import copy
 import matplotlib as mpl
 from matplotlib import pyplot as plt
@@ -15,7 +16,7 @@ from pahfit.errors import PAHFITModelError
 from pahfit.fitters.ap_components import (BlackBody1D, ModifiedBlackBody1D,
                                           S07_attenuation, att_Drude1D)
 from pahfit.fitters.ap_fitter import APFitter
-
+from astropy.nddata import StdDevUncertainty
 
 class Model:
     """This class acts as the main API for PAHFIT.
@@ -70,21 +71,23 @@ class Model:
         self.fit_info = None
 
     @classmethod
-    def from_yaml(cls, pack_file):
+    def from_yaml(cls, *pack_files):
         """
-        Generate feature table from YAML file.
+        Generate feature table from YAML file(s).
 
         Parameters
         ----------
-        pack_file : str
-            Path to YAML file, or name of one of the default YAML files.
+        pack_files : str, ...
+            Path to YAML file, or name of default YAML file. When more
+            than one is given, multiple packs will be combined. All
+            features in the given packs must have unique names.
 
         Returns
         -------
         Model instance
 
         """
-        features = Features.read(pack_file)
+        features = vstack([Features.read(pack_file) for pack_file in pack_files])
         return cls(features)
 
     @classmethod
@@ -138,7 +141,7 @@ class Model:
     def _repr_html_(self):
         return self._status_message() + self.features._repr_html_()
 
-    def guess(self, spec: Spectrum1D, redshift=None, integrate_line_flux=False,
+    def guess(self, spec: Spectrum1D, redshift=None, integrate_line_flux=True,
               calc_line_fwhm=True):
         """Make an initial guess of the physics, based on the given
         observational data.
@@ -231,7 +234,7 @@ class Model:
             bb = ModifiedBlackBody1D(1, temp)
             flux_ref = np.median(flux[(lam > lam_ref - 0.2) & (lam < lam_ref + 0.2)])
             amp_guess = flux_ref / bb(lam_ref)
-            return np.clip(amp_guess / nbb, 0, 1.)
+            return amp_guess / nbb  # np.clip(amp_guess / nbb, 0, 1.)
 
         loop_over_non_fixed("dust_continuum", "tau", dust_continuum_guess)
 
@@ -285,8 +288,17 @@ class Model:
             loop_over_non_fixed("line", "power",
                                 lambda row: power_guess(row, line_fwhm_guess(row)))
         else:
-            loop_over_non_fixed("line", "power",
-                                lambda row: median_flux * line_fwhm_guess(row))
+            loop_over_non_fixed(
+                "line",
+                "power",
+                # approximate power = fnu * dlambda * c / lambda**2 = intensity * fwhm * c / lambda**2
+                lambda row: (
+                    (median_flux * units.intensity)
+                    * (line_fwhm_guess(row) * units.wavelength)
+                    * constants.c
+                    / (row["wavelength"]["val"] * units.wavelength) ** 2)
+                .to(units.intensity_power)
+                .value)
 
         # Override the fwhms in the features table. Slightly different logic,
         # as the fwhm for lines are masked by default. TODO: leave FWHM
@@ -302,10 +314,10 @@ class Model:
                     # its elements is masked.  Table prevents setting
                     # values in such a masked array element, so we
                     # access the underlying array itself with .data
-                    self.features["fwhm"].data[row_index]['val'] = line_fwhm_guess(row)
-                    for b in ('min', 'max'):
+                    self.features["fwhm"].data[row_index]["val"] = line_fwhm_guess(row)
+                    for b in ("min", "max"):
                         self.features["fwhm"].data[row_index][b] = np.nan
-                    self.features["fwhm"].data[row_index]['frozen'] = False
+                    self.features["fwhm"].data[row_index]["frozen"] = False
                 elif not bounded_is_fixed(row["fwhm"]):
                     self.features["fwhm"].data[row_index]["val"] = line_fwhm_guess(row)
 
@@ -342,8 +354,14 @@ class Model:
         unc = unc_obs * (1 + z)  # uncertainty scales with flux
         return lam_obs, flux_obs, unc_obs, lam, flux, unc
 
-    def fit(self, spec: Spectrum1D, redshift=None, maxiter=1000, verbose=True,
-            use_instrument_fwhm=True):
+    def fit(
+        self,
+        spec: Spectrum1D,
+        redshift=None,
+        maxiter=1000,
+        verbose=True,
+        use_instrument_fwhm=True,
+        method=None):
         """Fit the observed data.
 
         The model setup is based on the features table and instrument
@@ -391,6 +409,9 @@ class Model:
             bounds are provided on the fwhm for a line, the fwhm for
             this line will be fit to the data.
 
+        method : str
+            String to select fitting backend and algorithm (developer option)
+
         """
         # parse spectral data
         self.features.meta["user_unit"]["flux"] = spec.flux.unit
@@ -405,13 +426,81 @@ class Model:
         instrument.check_range([min(x), max(x)], inst)
 
         self._set_up_fitter(inst, z, lam=x, use_instrument_fwhm=use_instrument_fwhm)
-        self.fitter.fit(lam, flux, unc, maxiter=maxiter)
+        self.fitter.fit(lam, flux, unc, maxiter=maxiter, method=method)
+        self.fit_info = self.fitter.fit_info
 
         # copy the fit results to the features table
         self._ingest_fit_result_to_features()
 
         if verbose:
             print(self.fitter.message)
+
+
+    def fit_broad_then_all(self, spec: Spectrum1D, redshift=None, maxiter=100000,
+                           verbose=True, use_instrument_fwhm=True, method="trf",
+                           stage1_freeze_kind="line", stage1_freeze_parameter="power",
+                           stage1_mask_lines=True, stage1_line_width_factor=4.0):
+        self.guess(spec, redshift=redshift, integrate_line_flux=True, calc_line_fwhm=False)
+
+        freeze_indices = np.where(self.features["kind"] == stage1_freeze_kind)[0]
+
+        saved_val = np.array(self.features[stage1_freeze_parameter].data["val"][freeze_indices], copy=True)
+        saved_min = np.array(self.features[stage1_freeze_parameter].data["min"][freeze_indices], copy=True)
+        saved_max = np.array(self.features[stage1_freeze_parameter].data["max"][freeze_indices], copy=True)
+        saved_frozen = np.array(self.features[stage1_freeze_parameter].data["frozen"][freeze_indices], copy=True)
+
+        self.features[stage1_freeze_parameter].data["val"][freeze_indices] = 0.0
+        self.features[stage1_freeze_parameter].data["frozen"][freeze_indices] = True
+
+        stage1_spec = spec
+        if stage1_mask_lines:
+            line_mask = self.line_pixel_mask(spec, redshift=redshift, width_factor=stage1_line_width_factor)
+            stage1_spec = self.spectrum_with_inflated_uncertainty(spec, line_mask)
+
+        self.fit(stage1_spec, redshift=redshift, maxiter=maxiter, verbose=verbose,
+                 use_instrument_fwhm=use_instrument_fwhm, method=method)
+
+        stage1_features = self.features.copy()
+
+        self.features[stage1_freeze_parameter].data["val"][freeze_indices] = saved_val
+        self.features[stage1_freeze_parameter].data["min"][freeze_indices] = saved_min
+        self.features[stage1_freeze_parameter].data["max"][freeze_indices] = saved_max
+        self.features[stage1_freeze_parameter].data["frozen"][freeze_indices] = saved_frozen
+
+        self.fit(spec, redshift=redshift, maxiter=maxiter, verbose=verbose,
+                 use_instrument_fwhm=use_instrument_fwhm, method=method)
+
+        return stage1_features, self.features.copy()
+
+    def relax_line_parameters(self, velocity_window=300.0, fwhm_min_velocity=80.0,
+                              fwhm_max_velocity=800.0, names=None):
+        c_kms = constants.c.to("km/s").value
+
+        for i in np.where(self.features["kind"] == "line")[0]:
+            name = str(self.features["name"][i])
+            if names is not None and name not in names:
+                continue
+
+            lam0 = float(self.features["wavelength"].data["val"][i])
+            if not np.isfinite(lam0):
+                continue
+
+            dlam = lam0 * velocity_window / c_kms
+            self.features["wavelength"].data["min"][i] = lam0 - dlam
+            self.features["wavelength"].data["max"][i] = lam0 + dlam
+            self.features["wavelength"].data["frozen"][i] = False
+
+            fwhm_min = lam0 * fwhm_min_velocity / c_kms
+            fwhm_max = lam0 * fwhm_max_velocity / c_kms
+            fwhm_val = self.features["fwhm"].data["val"][i]
+
+            if not np.isfinite(fwhm_val) or fwhm_val <= 0:
+                fwhm_val = np.sqrt(fwhm_min * fwhm_max)
+
+            self.features["fwhm"].data["val"][i] = np.clip(fwhm_val, fwhm_min, fwhm_max)
+            self.features["fwhm"].data["min"][i] = fwhm_min
+            self.features["fwhm"].data["max"][i] = fwhm_max
+            self.features["fwhm"].data["frozen"][i] = False
 
     def _ingest_fit_result_to_features(self):
         """Copy the results from the Fitter to the features table
@@ -434,8 +523,6 @@ class Model:
                     # do not update disabled attributes (e.g. line fwhm is usually masked)
                     if not bounded_is_disabled(self.features[column][i]):
                         self.features[column]["val"][i] = value
-                    else:
-                        self.features[column][i] = (value, np.nan, np.nan)
                 except Exception as e:
                     print(f"Could not assign to attribute {name} in features table.")
                     print(f"Index {i=}")
@@ -443,8 +530,9 @@ class Model:
                     raise e
 
     def plot(self, spec, redshift=None, use_instrument_fwhm=False,
-             label_lines=False, scalefac_resid=2, update_fig=None,
-             errorbar_kwargs=None, plot_kwargs=None, **kwargs):
+         label_lines=False, scalefac_resid=2, update_fig=None,
+         errorbar_kwargs=None, plot_kwargs=None, residual="percent",
+         residual_floor=None, **kwargs):
         """Plot model, and optionally compare to observational data.
 
         Parameters
@@ -634,26 +722,36 @@ class Model:
             handles.insert(0, ln_att)
         ax.legend(handles=handles, prop={"size": 10}, loc="best")
 
-        # residuals = data in rest frame - (model evaluated at rest frame wavelengths)
-        res = flux - self.tabulate(instrument, 0, lam).flux.value
-        std = np.nanstd(res)
+        
+        model_flux = self.tabulate(instrument, 0, lam).flux.value
+        res = flux - model_flux
+
+        if residual == "percent":
+            if residual_floor is None:
+                residual_floor = 0.01 * np.nanpercentile(np.abs(model_flux), 95)
+            denom = np.where(np.abs(model_flux) > residual_floor, np.abs(model_flux), residual_floor)
+            res_plot = 100.0 * res / denom
+            res_label = "Residuals (%)"
+        else:
+            res_plot = res
+            res_label = f"Residuals ({sp_unit})"
+
+        std = np.nanstd(res_plot)
         ax = axs[1]
 
         ax.set_yscale("linear")
         ax.set_xscale("log")
-        ax.tick_params(axis="both", which="major", top="on", right="on",
-                       direction="in", length=10)
-        ax.tick_params(axis="both", which="minor", top="on", right="on",
-                       direction="in", length=5)
+        ax.tick_params(axis="both", which="major", top="on", right="on", direction="in", length=10)
+        ax.tick_params(axis="both", which="minor", top="on", right="on", direction="in", length=5)
         ax.minorticks_on()
         ax.axhline(0, linestyle="--", color="gray", zorder=0)
-        ax.plot(lam, res, "ko", fillstyle="none", zorder=1,
+        ax.plot(lam, res_plot, "ko", fillstyle="none", zorder=1,
                 markersize=errorbar_kwargs.get("markersize", None),
                 alpha=errorbar_kwargs.get("alpha", None),
                 linestyle="none")
         ax.set_ylim(-scalefac_resid * std, scalefac_resid * std)
         ax.set_xlabel(r"$\lambda$ [$\mu m$]")
-        ax.set_ylabel(f"Residuals ({sp_unit})")
+        ax.set_ylabel(res_label)
 
         # Refine x-axis
         ax.set_xlim(mnlam, mxlam)
@@ -813,14 +911,12 @@ class Model:
         # also apply observed range if provided
         if lam_obs is not None:
             is_outside |= (lam_feature_obs < np.amin(lam_obs)) | (
-                lam_feature_obs > np.amax(lam_obs)
-            )
+                lam_feature_obs > np.amax(lam_obs))
 
         # restriction on the kind of feature that can be excluded
         excludable = ["line", "dust_feature", "absorption"]
         is_excludable = np.logical_or.reduce(
-            [kind == self.features["kind"] for kind in excludable]
-        )
+            [kind == self.features["kind"] for kind in excludable])
 
         return is_outside & is_excludable
 
@@ -882,14 +978,14 @@ class Model:
             name = row["name"]
 
             if kind == "starlight":
-                self.fitter.add_feature_starlight(
-                    name, cleaned(row["temperature"]), cleaned(row["tau"])
-                )
+                self.fitter.add_feature_starlight(name, cleaned(row["temperature"]), cleaned(row["tau"]))
 
             elif kind == "dust_continuum":
                 self.fitter.add_feature_dust_continuum(
-                    name, cleaned(row["temperature"]), cleaned(row["tau"])
-                )
+                    name,
+                    cleaned(row["temperature"]),
+                    cleaned(row["tau"]),
+                    model=row["model"])
 
             elif kind == "line":
                 # be careful with lines that have masked FWHM values here
@@ -922,16 +1018,14 @@ class Model:
                     fwhm = cleaned(row["fwhm"])
 
                 self.fitter.add_feature_line(
-                    name, cleaned(row["power"]), cleaned(row["wavelength"]), fwhm
-                )
+                    name, cleaned(row["power"]), cleaned(row["wavelength"]), fwhm)
 
             elif kind == "dust_feature":
                 self.fitter.add_feature_dust_feature(
                     name,
                     cleaned(row["power"]),
                     cleaned(row["wavelength"]),
-                    cleaned(row["fwhm"]),
-                )
+                    cleaned(row["fwhm"]))
 
             elif kind == "attenuation":
                 self.fitter.add_feature_attenuation(name, cleaned(row["tau"]))
@@ -941,14 +1035,7 @@ class Model:
                     name,
                     cleaned(row["tau"]),
                     cleaned(row["wavelength"]),
-                    cleaned(row["fwhm"]),
-                )
-
-            else:
-                raise PAHFITModelError(
-                    f"Model components of kind {kind} are not implemented!"
-                )
-
+                    cleaned(row["fwhm"]))
         self.fitter.finalize()
 
     @staticmethod
@@ -965,3 +1052,39 @@ class Model:
             raise PAHFITModelError("No instrument! Please set spec.meta['instrument'].")
 
         return inst, z
+
+    def line_pixel_mask(self, spec: Spectrum1D, redshift=None, width_factor=4.0):
+        inst, z = self._parse_instrument_and_redshift(spec, redshift)
+        lam_obs = spec.spectral_axis.to(u.micron).value
+        mask = np.zeros(lam_obs.shape, dtype=bool)
+
+        for row in self.features[self.features["kind"] == "line"]:
+            line_obs = row["wavelength"]["val"] * (1.0 + z)
+            if not np.isfinite(line_obs) or not instrument.within_segment(line_obs, inst):
+                continue
+
+            fwhm_obs = instrument.fwhm(inst, line_obs, as_bounded=True)[0][0]
+            if np.ma.is_masked(fwhm_obs) or not np.isfinite(fwhm_obs) or fwhm_obs <= 0:
+                continue
+
+            mask |= np.abs(lam_obs - line_obs) <= width_factor * float(fwhm_obs)
+
+        return mask
+
+    def spectrum_with_inflated_uncertainty(self, spec: Spectrum1D, mask, inflate_factor=1.0e9):
+        new_unc = np.array(spec.uncertainty.array, dtype=float, copy=True)
+        good_unc = new_unc[np.isfinite(new_unc) & (new_unc > 0)]
+        floor_unc = np.nanmedian(good_unc) if len(good_unc) > 0 else 1.0
+
+        new_unc[mask] = np.maximum(new_unc[mask], floor_unc) * inflate_factor
+
+        stage1_spec = Spectrum1D(flux=spec.flux.copy(),
+                         spectral_axis=spec.spectral_axis.to(u.micron).value * u.micron,
+                         uncertainty=StdDevUncertainty(new_unc),
+                         meta=copy.deepcopy(spec.meta))
+
+        z = getattr(spec.redshift, "value", spec.redshift)
+        if z is not None:
+            stage1_spec.set_redshift_to(z)
+
+        return stage1_spec

--- a/pahfit/model.py
+++ b/pahfit/model.py
@@ -398,8 +398,8 @@ class Model:
         x, _, _, lam, flux, unc = self._convert_spec_data(spec, z)
 
         # save these as part of the model (will be written to disk too)
-        self.features.meta["redshift"] = inst
-        self.features.meta["instrument"] = z
+        self.features.meta["redshift"] = z
+        self.features.meta["instrument"] = inst
 
         # check if observed spectrum is compatible with instrument model
         instrument.check_range([min(x), max(x)], inst)

--- a/pahfit/packs/science/classic_normal.yaml
+++ b/pahfit/packs/science/classic_normal.yaml
@@ -1,0 +1,194 @@
+# PAHFIT Classic Model Pack
+# Implements the classic IDL-based PAHFIT v1.2 model of Smith et al.,
+# 2007
+#
+#  v0.1, May 2022
+#
+# Note that the IDL PAHFIT model was originally designed only for
+# Spitzer/IRS spectra, and included:
+# 
+#   - a fixed +-0.05 micron undertainty bounds on all line wavelengths
+#   - fixed line FWHM "breaks" with fractional bounds of 10%
+#   
+# Since FWHM is now a detail of the instrument pack (see
+# packs/instrument), some small fitting differences are anticipated
+# compared to IDL PAHFIT, even when applying to Spitzer/IRS spectra.
+
+#######################
+# Starlight continuum #
+#######################
+starlight:
+    kind: starlight
+    temperature: 5000
+
+##################
+# Dust continuum #
+##################
+dust_cont: # Modified Blackbodies
+    kind: dust_continuum
+    temperature: [300, 200, 135, 90, 65, 50, 40, 35]
+
+##############################
+# H_2 Line Emission Features #
+##############################
+H2_lines:
+    kind: line
+    wavelength:
+#        H2_S(9):    4.6947
+#        H2_S(8):    5.0529
+        H2_S(7):    5.5115
+        H2_S(6):    6.1088
+        H2_S(5):    6.9091
+        H2_S(4):    8.0258
+        H2_S(3):    9.6649
+        H2_S(2):   12.2785
+        H2_S(1):   17.0346
+        H2_S(0):   28.2207
+
+################################
+# Ionic Line Emission Features #
+################################
+ionic_lines:
+    kind: line
+    wavelength:
+#        'Bra':     4.0523
+        '[FeII]':     5.3401
+#       '[Mg V]':     5.6100  
+        '[ArII]':     6.985274
+#       '[NeVI]':     7.6524
+#       '[ArV]':      7.9016
+        '[ArIII]':    8.99138
+        '[SIV]':     10.5105
+        '[NeII]':    12.813
+        '[NeV]':     14.3217
+        '[NeIII]':   15.555
+        '[SIII]_18': 18.713
+        '[OIV]':     25.91
+#        '[FeII]_26': 25.989
+
+#################
+# Dust Features #
+#################
+
+
+PAH_5.3:
+    kind: dust_feature
+    wavelength: 5.27
+    fwhm: 0.17918
+    
+PAH_5.7:
+    kind: dust_feature
+    wavelength: 5.7
+    fwhm: 0.1995
+    
+PAH_6.2:
+    kind: dust_feature
+    wavelength: 6.22
+    fwhm: 0.1866
+    
+PAH_6.7:
+    kind: dust_feature
+    wavelength: 6.69
+    fwhm: 0.4683
+
+PAH_7.7_cmp:
+    kind: dust_feature
+    features:
+        PAH_7.7a:
+            wavelength: 7.42
+            fwhm: 0.93492
+        PAH_7.7b:
+            wavelength: 7.6
+            fwhm: 0.3344
+        PAH_7.7c:
+            wavelength: 7.85
+            fwhm: 0.41605
+
+PAH_8.3:
+    kind: dust_feature
+    wavelength: 8.33
+    fwhm: 0.4165
+    
+PAH_8.6:
+    kind: dust_feature
+    wavelength: 8.61
+    fwhm: 0.33579
+
+PAH_10.7:
+    kind: dust_feature
+    wavelength: 10.68
+    fwhm: 0.2136
+
+PAH_11.3_cmp:
+    kind: dust_feature
+    features:    
+        PAH_11.3a:
+            wavelength: 11.23
+            fwhm: 0.13476
+        PAH_11.3b:
+            wavelength: 11.33
+            fwhm: 0.36256
+
+PAH_12:
+    kind: dust_feature
+    wavelength: 11.99
+    fwhm: 0.53955
+
+PAH_12.6_cmp:
+    kind: dust_feature
+    features:    
+        PAH_12.6a:
+            wavelength: 12.62
+            fwhm: 0.53004
+        PAH_12.6b:
+            wavelength: 12.69
+            fwhm: 0.16497
+PAH_13.48:
+    kind: dust_feature
+    wavelength: 13.48
+    fwhm: 0.5392
+    
+PAH_14.04:
+    kind: dust_feature
+    wavelength: 14.04
+    fwhm: 0.22464
+    
+PAH_14.19:
+    kind: dust_feature
+    wavelength: 14.19
+    fwhm: 0.35475
+    
+PAH_15.9:
+    kind: dust_feature
+    wavelength: 15.9
+    fwhm: 0.318
+
+PAH_17_cmp:
+    kind: dust_feature
+    features:    
+        PAH_17a: 
+            wavelength: 16.45
+            fwhm: 0.2303
+        PAH_17b:
+            wavelength: 17.04
+            fwhm: 1.1076
+        PAH_17c:
+            wavelength: 17.37
+            fwhm: 0.2085
+        PAH_17d:
+            wavelength: 17.87
+            fwhm: 0.28592
+
+# This dust feature, in the PAHFIT classic model, is attributed to C60 and omitted.
+PAH_18.92:
+    kind: dust_feature
+    wavelength: 18.92
+    fwhm: 0.35948
+
+##########################
+# Attenuation Model      #
+##########################
+silicate:
+    kind: attenuation
+    model: S07_attenuation
+    geometry: mixed


### PR DESCRIPTION
Summary:
- Adds helper output for covariance-derived parameter uncertainties.
- Adds a feature-table display helper with numeric uncertainty columns and readable value \pm (plus minus) uncertainty columns.
- Keeps the full covariance matrix available as an optional diagnostic.
- Mostly distilled and preserves PAHFIT Ver.2.6.99
        - Preserves access to both LM and TRFLSQ fitting through the existing fitter method interface.
        - Preserves bounded/frozen parameter handling when reporting fitted values and uncertainties.
 
Notes:
- The reported uncertainties are formal covariance-based uncertainties from the Astropy fitter (fit-statistical uncertainties).