### PR TITLE
Add normalized BlackBody/ModifiedBlackBody + guess function improvements

### DIFF
--- a/pahfit/fitters/ap_components.py
+++ b/pahfit/fitters/ap_components.py
@@ -9,6 +9,14 @@ from pahfit import units
 __all__ = ["BlackBody1D", "ModifiedBlackBody1D", "S07_attenuation", "att_Drude1D"]
 
 
+def bb(x, temperature):
+    return (
+        3.9728917e13  # 2 h c/µm^3 -> MJy
+        / x**3
+        / (np.exp(1.4387752e4 / x / temperature) - 1.0)
+    )  # h c/micron k K
+
+
 class BlackBody1D(Fittable1DModel):
     """
     A blackbody component.
@@ -20,15 +28,12 @@ class BlackBody1D(Fittable1DModel):
     amplitude = Parameter()
     temperature = Parameter()
 
+    norm = bb(3, 5000)
+
     @staticmethod
     def evaluate(x, amplitude, temperature):
         """ """
-        return (
-            amplitude
-            * 3.9728917e13 # 2 h c/µm^3 -> MJy
-            / x**3 
-            / (np.exp(1.4387752e4 / x / temperature) - 1.0)  # h c/micron k K
-        )
+        return amplitude * bb(x, temperature) / BlackBody1D.norm
 
 
 class ModifiedBlackBody1D(BlackBody1D):
@@ -38,7 +43,9 @@ class ModifiedBlackBody1D(BlackBody1D):
 
     @staticmethod
     def evaluate(x, amplitude, temperature):
-        return BlackBody1D.evaluate(x, amplitude, temperature) * ((9.7 / x) ** 2)
+        bb_val = BlackBody1D.evaluate(x, 1, temperature) * ((9.7 / x) ** 2)
+        bb_ref = BlackBody1D.evaluate(17, 1, temperature) * ((9.7 / 17) ** 2)
+        return amplitude * bb_val / bb_ref
 
 
 class S07_attenuation(Fittable1DModel):

--- a/pahfit/fitters/ap_components.py
+++ b/pahfit/fitters/ap_components.py
@@ -43,8 +43,8 @@ class ModifiedBlackBody1D(BlackBody1D):
 
     @staticmethod
     def evaluate(x, amplitude, temperature):
-        bb_val = BlackBody1D.evaluate(x, 1, temperature) * ((9.7 / x) ** 2)
-        bb_ref = BlackBody1D.evaluate(17, 1, temperature) * ((9.7 / 17) ** 2)
+        bb_val = bb(x, temperature) * ((9.7 / x) ** 2)
+        bb_ref = bb(17, temperature) * ((9.7 / 17) ** 2)
         return amplitude * bb_val / bb_ref
 
 

--- a/pahfit/model.py
+++ b/pahfit/model.py
@@ -231,7 +231,7 @@ class Model:
             bb = ModifiedBlackBody1D(1, temp)
             flux_ref = np.median(flux[(lam > lam_ref - 0.2) & (lam < lam_ref + 0.2)])
             amp_guess = flux_ref / bb(lam_ref)
-            return amp_guess / nbb
+            return np.clip(amp_guess / nbb, 0, None)
 
         loop_over_non_fixed("dust_continuum", "tau", dust_continuum_guess)
 

--- a/pahfit/model.py
+++ b/pahfit/model.py
@@ -231,7 +231,7 @@ class Model:
             bb = ModifiedBlackBody1D(1, temp)
             flux_ref = np.median(flux[(lam > lam_ref - 0.2) & (lam < lam_ref + 0.2)])
             amp_guess = flux_ref / bb(lam_ref)
-            return np.clip(amp_guess / nbb, 0, 1.)
+            return amp_guess / nbb
 
         loop_over_non_fixed("dust_continuum", "tau", dust_continuum_guess)
 
@@ -285,8 +285,19 @@ class Model:
             loop_over_non_fixed("line", "power",
                                 lambda row: power_guess(row, line_fwhm_guess(row)))
         else:
-            loop_over_non_fixed("line", "power",
-                                lambda row: median_flux * line_fwhm_guess(row))
+            loop_over_non_fixed(
+                "line",
+                "power",
+                # approximate power = fnu * dlambda * c / lambda**2 = intensity * fwhm * c / lambda**2
+                lambda row: (
+                    (median_flux * units.intensity)
+                    * (line_fwhm_guess(row) * units.wavelength)
+                    * constants.c
+                    / (row["wavelength"]["val"] * units.wavelength) ** 2
+                )
+                .to(units.intensity_power)
+                .value,
+            )
 
         # Override the fwhms in the features table. Slightly different logic,
         # as the fwhm for lines are masked by default. TODO: leave FWHM
@@ -302,10 +313,10 @@ class Model:
                     # its elements is masked.  Table prevents setting
                     # values in such a masked array element, so we
                     # access the underlying array itself with .data
-                    self.features["fwhm"].data[row_index]['val'] = line_fwhm_guess(row)
-                    for b in ('min', 'max'):
+                    self.features["fwhm"].data[row_index]["val"] = line_fwhm_guess(row)
+                    for b in ("min", "max"):
                         self.features["fwhm"].data[row_index][b] = np.nan
-                    self.features["fwhm"].data[row_index]['frozen'] = False
+                    self.features["fwhm"].data[row_index]["frozen"] = False
                 elif not bounded_is_fixed(row["fwhm"]):
                     self.features["fwhm"].data[row_index]["val"] = line_fwhm_guess(row)
 


### PR DESCRIPTION
Note: Per [jdtsmith](https://github.com/jdtsmith)'s preferred PR ordering, this is intended to merge after the following PRs are completed:
1. Adding TRF model type
2. Add code to interpret 'param_cov' / feature table param mapping

This PR doesn't have a technical dependency on either of the PRs stated above as it has been tested and
can merge cleanly on its own; however, holding off respects the agreed sequencing.

This PR ports BB normalization and guess improvements from PR #308 (drvdputt, orion+galaxy_paper
branch) per the new PR plan in the "Ben Trana Summer" google doc (item 3).

**`ap_components.py`**
- `BlackBody1D`/`ModifiedBlackBody1D` now normalize against a fixed
  reference point (3µm/5000K and 17µm respectively) instead of raw
  amplitude. It provides the same physical fits, but better-behaved numbers internally.

**`model.py`**
- Removed an `np.clip(0, 1)` that was capping the dust continuum guess. It could hand the optimizer an artificial or wrong starting point.
- Line power guess now uses a real unit-aware formula (`fnu * dlambda * c / lambda**2`) instead of an unscaled approximation.
- Minor quote-style cleanup (single → double quotes) in the FWHM guess section, no behavior change whatsoever.

**Testing:** Ran an M83 example notebook. The fit converged, final spectrum matches the pre-change version, fitted values are all sane (no NaNs).