### PR TITLE
Fix resources.files() path resolution for editable installs

### DIFF
--- a/pahfit/features/features.py
+++ b/pahfit/features/features.py
@@ -18,12 +18,12 @@ tables are therefore also available for pahfit.features.Features.
 """
 
 import os
+from pathlib import Path
 from warnings import warn
 from astropy.table.table import MaskedColumn
 import numpy as np
 from astropy.table import vstack, Table, TableAttribute
 from astropy.io.misc.yaml import yaml
-from importlib import resources
 
 from pahfit.errors import PAHFITFeatureError, PAHFITWarning
 from pahfit.features.features_format import BoundedParTableFormatter
@@ -118,7 +118,7 @@ class Features(Table):
         feat_tables = dict()
 
         if not os.path.isfile(file):
-            file = resources.files("pahfit") / "packs/science" / file
+            file = Path(__file__).parent.parent / "packs" / "science" / file
         try:
             with open(file) as fd:
                 scipack = yaml.load(fd, Loader=UniqueKeyLoader)

--- a/pahfit/helpers.py
+++ b/pahfit/helpers.py
@@ -1,5 +1,5 @@
 import os
-from importlib import resources
+from pathlib import Path
 
 from pahfit import units
 
@@ -32,7 +32,7 @@ def find_packfile(packfile):
     if os.path.isfile(packfile):
         packfile_found = packfile
     else:
-        test_packfile = resources.files("pahfit") / "packs/science" / packfile
+        test_packfile = Path(__file__).parent / "packs" / "science" / packfile
         if os.path.isfile(test_packfile):
             packfile_found = test_packfile
         else:
@@ -62,7 +62,7 @@ def read_spectrum(specfile, format=None):
     """
     # resolve filename
     if not os.path.isfile(specfile):
-        test_specfile = resources.files("pahfit") / "data" / specfile
+        test_specfile = Path(__file__).parent / "data" / specfile
         if os.path.isfile(test_specfile):
             specfile = test_specfile
         else:

--- a/pahfit/instrument.py
+++ b/pahfit/instrument.py
@@ -14,7 +14,6 @@ from pathlib import Path
 import numpy as np
 from numpy.polynomial import Polynomial
 from astropy.io.misc import yaml
-from importlib import resources
 from pahfit.errors import PAHFITPackError, PAHFITWarning
 from warnings import warn
 
@@ -25,7 +24,8 @@ def read_instrument_packs():
     """Read all instrument packs into the 'packs' variable."""
     global packs
     packs = {}
-    for pack in (resources.files("pahfit") / "packs/instrument").glob("*.yaml"):
+    pack_dir = Path(__file__).parent / "packs" / "instrument"
+    for pack in pack_dir.glob("*.yaml"):
         try:
             with open(pack) as fd:
                 p = yaml.load(fd)


### PR DESCRIPTION
**Summary:** PAHFIT couldn't locate its own data files (instrument and science packs) for editable installs which is the standard setup for active development, therefore causing core functions to fail. This was fixed by replacing the broken file-location method with a reliable one.

## What this fixes

`resources.files("pahfit")` is used in several places to locate PAHFIT's package data files (instrument YAML packs, science YAML packs, and example data files). For editable installs (`pip install -e .`), this resolves to the wrong location — it points at the system site-packages directory instead of the actual source tree causing a `FileNotFoundError` or silent empty results when loading instrument packs or science packs.

This breaks core functionality for anyone developing PAHFIT with an editable install, including `model.guess()`, `Model.from_yaml()`, and spectrum reading.

## Changes

Replaced all five `resources.files("pahfit")` calls with `Path(__file__).parent`-based resolution, which correctly locates files relative to the actual module on disk regardless of install method:

- `pahfit/instrument.py` — instrument pack loading (`read_instrument_packs`)
- `pahfit/features/features.py` — science pack loading (`_read_scipack`)
- `pahfit/helpers.py` — science pack lookup (`find_packfile`) and example spectrum lookup (`read_spectrum`)

I also removed the now-unused `from importlib import resources` import from all three files as nothing in these three files calls resources anymore.

## How I found this

While trying to run a notebook with an editable install, `model.guess()` failed with a `ValueError` from an empty sequence, traced back to `instrument.packs` being empty — which traced back to `resources.files()` resolving to the wrong location.

## Testing

This was verified by restarting the kernel and re-running an example notebook (M83 fit) end-to-end. It now completes without errors.

