### PR TITLE
Add selectable astropy fitting methods

### DIFF
--- a/pahfit/fitters/ap_fitter.py
+++ b/pahfit/fitters/ap_fitter.py
@@ -234,13 +234,13 @@ class APFitter(Fitter):
         Parameters
         ----------
         lam : array
-            Rest-frame wavelengths in micron.
+            Rest frame wavelengths in micron.
 
         flux : array
-            Rest-frame flux in PAHFIT internal units.
+            Rest frame flux in internal units.
 
         unc : array
-            Uncertainty on the rest-frame flux.
+            Uncertainty on rest frame flux. Same units as flux.
 
         maxiter : int
             Maximum number of fitting iterations or function
@@ -252,13 +252,9 @@ class APFitter(Fitter):
             ``TRFLSQFitter``. If None, the first available method,
             currently ``"lm"``, is used.
         """
-        weights = 1.0 / unc
+        w = 1 / unc
 
-        mask = (
-            np.isfinite(lam)
-            & np.isfinite(flux)
-            & np.isfinite(weights))
-
+        mask = (np.isfinite(lam) & np.isfinite(flux) & np.isfinite(w))
         method_str = self.methods[0] if method is None else method
 
         if method_str not in self.methods:
@@ -277,16 +273,14 @@ class APFitter(Fitter):
             self.model,
             lam[mask],
             flux[mask],
-            weights=weights[mask],
+            w=w[mask],
             maxiter=maxiter,
-            epsilon=1e-10,
-            acc=1e-10)
+            epsilon=1e-7,
+            acc=1e-7)
 
         self.model = fitted_model
         self.fit_info = fitter.fit_info
         self.message = fitter.fit_info["message"]
-
-
 
     def get_result(self, component_name):
         """Retrieve results from astropy model component.

--- a/pahfit/fitters/ap_fitter.py
+++ b/pahfit/fitters/ap_fitter.py
@@ -8,7 +8,7 @@ from .ap_components import (
     PowerDrude1D,
     PowerGaussian1D,
 )
-from astropy.modeling.fitting import LevMarLSQFitter
+from astropy.modeling.fitting import LevMarLSQFitter, TRFLSQFitter
 import numpy as np
 
 
@@ -69,6 +69,8 @@ class APFitter(Fitter):
         self.feature_types = {}
         self.model = None
         self.message = None
+        self.fit_info = None
+        self.methods = ["lm", "trf"]
 
     def finalize(self):
         """Sum the registered components into one CompoundModel.
@@ -222,60 +224,69 @@ class APFitter(Fitter):
         """
         return self.model(lam)
 
-    def fit(self, lam, flux, unc, maxiter=10000):
-        """Fit the internal model using the astropy fitter.
+    def fit_methods_available(self):
+        """Return the fitting methods available for this backend."""
+        return self.methods
 
-        The fitter class is unit agnostic, and deal with the numbers the
-        Model tells it to deal with. Internal renormalizations could be
-        good to consider, as long as any values are converted back to
-        the original system before returning them. In practice, the
-        input spectrum is expected to be in internal units, and orrected
-        for redshift (models operate in the rest frame).
-
-        After the fit, the results can be retrieved via get_result().
-
-        Retrieval of uncertainties and fit details is yet to be
-        implemented.
-
-        CAVEAT: flux unit (flux) is still ambiguous, since it can be
-        flux density or intensity, according to the options defined in
-        pahfit.units. After the fit, the return units of "power" in
-        get_results depend on the given spectrum (they will be flux unit
-        times wavelength unit).
+    def fit(self, lam, flux, unc, maxiter=10000, method=None):
+        """Fit the internal model using an Astropy fitter.
 
         Parameters
         ----------
         lam : array
-            Rest frame wavelengths in micron
+            Rest-frame wavelengths in micron.
 
         flux : array
-            Rest frame flux in internal units.
+            Rest-frame flux in PAHFIT internal units.
 
         unc : array
-            Uncertainty on rest frame flux. Same units as flux.
+            Uncertainty on the rest-frame flux.
 
+        maxiter : int
+            Maximum number of fitting iterations or function
+            evaluations.
+
+        method : {"lm", "trf"} or None
+            Astropy fitting method. ``"lm"`` uses
+            ``LevMarLSQFitter`` and ``"trf"`` uses
+            ``TRFLSQFitter``. If None, the first available method,
+            currently ``"lm"``, is used.
         """
-        # clean, because astropy does not like nan
-        w = 1 / unc
+        weights = 1.0 / unc
 
-        # make sure there are no zero uncertainties either
-        mask = np.isfinite(lam) & np.isfinite(flux) & np.isfinite(w)
+        mask = (
+            np.isfinite(lam)
+            & np.isfinite(flux)
+            & np.isfinite(weights))
 
-        self.fit_info = []
+        method_str = self.methods[0] if method is None else method
 
-        fit = LevMarLSQFitter(calc_uncertainties=True)
-        astropy_result = fit(
+        if method_str not in self.methods:
+            raise PAHFITModelError(
+                f"Selected method {method} not available "
+                "for APFitter backend.")
+
+        if method_str == "lm":
+            fitter_cls = LevMarLSQFitter
+        else:
+            fitter_cls = TRFLSQFitter
+
+        fitter = fitter_cls(calc_uncertainties=True)
+
+        fitted_model = fitter(
             self.model,
             lam[mask],
             flux[mask],
-            weights=w[mask],
+            weights=weights[mask],
             maxiter=maxiter,
             epsilon=1e-10,
-            acc=1e-10,
-        )
-        self.fit_info = fit.fit_info
-        self.model = astropy_result
-        self.message = fit.fit_info["message"]
+            acc=1e-10)
+
+        self.model = fitted_model
+        self.fit_info = fitter.fit_info
+        self.message = fitter.fit_info["message"]
+
+
 
     def get_result(self, component_name):
         """Retrieve results from astropy model component.

--- a/pahfit/fitters/ap_fitter.py
+++ b/pahfit/fitters/ap_fitter.py
@@ -220,7 +220,7 @@ class APFitter(Fitter):
         Returns
         -------
         flux : array
-            Rest frame flux in internal units
+            Rest frame flux in internal units.
         """
         return self.model(lam)
 
@@ -252,9 +252,11 @@ class APFitter(Fitter):
             ``TRFLSQFitter``. If None, the first available method,
             currently ``"lm"``, is used.
         """
+        # clean, because astropy does not like nan
         w = 1 / unc
 
-        mask = (np.isfinite(lam) & np.isfinite(flux) & np.isfinite(w))
+        # make sure there are no zero uncertainties either
+        mask = np.isfinite(lam) & np.isfinite(flux) & np.isfinite(w)
         method_str = self.methods[0] if method is None else method
 
         if method_str not in self.methods:

--- a/pahfit/fitters/ap_fitter.py
+++ b/pahfit/fitters/ap_fitter.py
@@ -277,8 +277,8 @@ class APFitter(Fitter):
             flux[mask],
             w=w[mask],
             maxiter=maxiter,
-            epsilon=1e-7,
-            acc=1e-7)
+            epsilon=1e-10,
+            acc=1e-10)
 
         self.model = fitted_model
         self.fit_info = fitter.fit_info

--- a/pahfit/fitters/fitter.py
+++ b/pahfit/fitters/fitter.py
@@ -147,7 +147,12 @@ class Fitter(ABC):
         pass
 
     @abstractmethod
-    def fit(self, lam, flux, unc, maxiter=1000):
+    def fit_methods_available(self):
+        """Return the fitting methods available for this backend."""
+        return [None]
+
+    @abstractmethod
+    def fit(self, lam, flux, unc, maxiter=1000, method=None):
         """Perform the fit using the framework of the subclass.
 
         :class:`~pahfit.fitters.Fitter` is unit agnostic, and deals
@@ -168,6 +173,10 @@ class Fitter(ABC):
 
         unc : array
             Uncertainty in the rest-frame flux.  Same units as flux.
+
+        method : str or None
+            Override the fitting method. Available values are returned
+            by ``fit_methods_available()`` for the selected backend.
         """
         pass
 

--- a/pahfit/model.py
+++ b/pahfit/model.py
@@ -354,7 +354,7 @@ class Model:
         return lam_obs, flux_obs, unc_obs, lam, flux, unc
 
     def fit(self, spec: Spectrum1D, redshift=None, maxiter=1000, verbose=True,
-            use_instrument_fwhm=True):
+            use_instrument_fwhm=True, method=None):
         """Fit the observed data.
 
         The model setup is based on the features table and instrument
@@ -402,6 +402,10 @@ class Model:
             bounds are provided on the fwhm for a line, the fwhm for
             this line will be fit to the data.
 
+        method : {"lm", "trf"} or None
+            Fitting method passed to the active fitter backend. If None,
+            the backend default is used; for APFitter this remains LM.
+
         """
         # parse spectral data
         self.features.meta["user_unit"]["flux"] = spec.flux.unit
@@ -416,7 +420,7 @@ class Model:
         instrument.check_range([min(x), max(x)], inst)
 
         self._set_up_fitter(inst, z, lam=x, use_instrument_fwhm=use_instrument_fwhm)
-        self.fitter.fit(lam, flux, unc, maxiter=maxiter)
+        self.fitter.fit(lam, flux, unc, maxiter=maxiter, method=method)
 
         # copy the fit results to the features table
         self._ingest_fit_result_to_features()


### PR DESCRIPTION
Now officially implemented "lm" and "trf" fitter methods.
(Based on Dries' PR #308)
e.g.,
model.guess(spec)
model.fit(spec, maxiter=10000, use_instrument_fwhm=False, method="lm")
model.fit(spec, maxiter=100000, use_instrument_fwhm=False, method="trf")
_ = model.plot(spec, scalefac_resid=1, label_lines=False, alpha=0.2)