### PR TITLE
Add required sphinx.configuration key to .readthedocs.yml

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,6 +5,9 @@ build:
   tools:
     python: "3.12"
 
+sphinx:
+  configuration: docs/conf.py
+
 python:
   install:
     - method: pip
@@ -15,4 +18,3 @@ python:
 
 # Don't build any extra formats
 formats: []
-


### PR DESCRIPTION
On January 20, 2025, Read the Docs made the sphinx.configuration key mandatory in .readthedocs.yml. 

Without it, the docs build fails immediately on every PR with an error stating "Missing Sphinx configuration key." 

This PR adds the one required line pointing to docs/conf.py, which is where PAHFIT's Sphinx config already lives. There are no other changes in this PR.