### PR TITLE
Dual-unit support: flux density + surface brightness + getting units out of features table

### DIFF
--- a/pahfit/fitters/ap_components.py
+++ b/pahfit/fitters/ap_components.py
@@ -176,6 +176,10 @@ class PowerDrude1D(Fittable1DModel):
         .to(units.intensity)
         .value
     )
+
+    # ASSUMPTION (needs Dr. Smith's verification): mirrors
+    # intensity_amplitude_factor above, substituting flux_power/
+    # flux_density. Dimensionally valid; not yet physically confirmed.
     flux_amplitude_factor = (
         (2 * units.flux_power * units.wavelength / (constants.c * np.pi))
         .to(units.flux_density)
@@ -279,6 +283,10 @@ class PowerGaussian1D(Fittable1DModel):
         .to(units.intensity)
         .value
     )
+
+    # ASSUMPTION (needs Dr. Smith's verification): mirrors
+    # intensity_amplitude_factor above, substituting flux_power/
+    # flux_density. Dimensionally valid; not yet physically confirmed.
     flux_amplitude_factor = (
         (
             units.flux_power

--- a/pahfit/fitters/ap_components.py
+++ b/pahfit/fitters/ap_components.py
@@ -159,22 +159,26 @@ class PowerDrude1D(Fittable1DModel):
     are the internal pahfit units defined in pahfit.units, and
     precalculate a conversion factor.
 
-    TODO: We need to check if the flux is 'intensity' or 'flux_density',
-    and assume the power parameter has 'intensity_power' or
-    'flux_density_power' units respectively. For now, only intensity is
-    supported.
-
+    Both intensity (surface brightness, MJy/sr) and flux density (mJy)
+    inputs are supported. The appropriate amplitude factor is selected
+    at evaluate time based on which unit track is active.
     """
-
     power = Parameter(min=0.0)
     x_0 = Parameter(min=0.0)
     fwhm = Parameter(default=1, min=0.0)
-
+    
     # constant factors in the equation to convert power to amplitude of
-    # the profile.
+    # the profile. Two versions: one for surface brightness input
+    # (intensity_power -> intensity) and one for flux density input
+    # (flux_power -> flux_density).
     intensity_amplitude_factor = (
         (2 * units.intensity_power * units.wavelength / (constants.c * np.pi))
         .to(units.intensity)
+        .value
+    )
+    flux_amplitude_factor = (
+        (2 * units.flux_power * units.wavelength / (constants.c * np.pi))
+        .to(units.flux_density)
         .value
     )
 
@@ -221,7 +225,8 @@ class PowerDrude1D(Fittable1DModel):
         # factor = (2 * unit(power) * unit(wavelength) / (pi * c)).to(unit(intensity))
 
         g = fwhm / x_0
-        b = power * x_0 / g * self.intensity_amplitude_factor
+        factor = self.flux_amplitude_factor if getattr(self, 'is_flux', False) else self.intensity_amplitude_factor
+        b = power * x_0 / g * factor
         return b * g**2 / ((x / x_0 - x_0 / x) ** 2 + g**2)
 
 
@@ -256,6 +261,9 @@ class PowerGaussian1D(Fittable1DModel):
     So the constant factor we can set is
     (unit(power) * unit(wavelength)**2 / (c * unit(wavelength) * sqrt(2 pi))).to(intensity)
 
+    Both intensity (surface brightness, MJy/sr) and flux density (mJy)
+    inputs are supported. The appropriate amplitude factor is selected
+    at evaluate time based on which unit track is active.
     """
 
     power = Parameter(min=0.0)
@@ -271,6 +279,15 @@ class PowerGaussian1D(Fittable1DModel):
         .to(units.intensity)
         .value
     )
+    flux_amplitude_factor = (
+        (
+            units.flux_power
+            * (units.wavelength) ** 2
+            / (constants.c * units.wavelength * np.sqrt(2 * np.pi))
+        )
+        .to(units.flux_density)
+        .value
+    )
 
     def evaluate(self, x, power, mean, stddev):
         """
@@ -278,6 +295,7 @@ class PowerGaussian1D(Fittable1DModel):
 
         See class description for equations and unit notes."""
 
-        # amplitude in intensity units
-        Anu = power * mean**2 / stddev * self.intensity_amplitude_factor
+        # amplitude in intensity or flux density units
+        factor = self.flux_amplitude_factor if getattr(self, 'is_flux', False) else self.intensity_amplitude_factor
+        Anu = power * mean**2 / stddev * factor
         return Anu * np.exp(-0.5 * np.square((x - mean) / stddev))

--- a/pahfit/fitters/ap_components.py
+++ b/pahfit/fitters/ap_components.py
@@ -170,11 +170,6 @@ class PowerDrude1D(Fittable1DModel):
     def _amplitude_factor(self):
         """Conversion factor from power to profile amplitude, computed
         for whichever unit track (flux or surface brightness) is active.
-
-        # ASSUMPTION (needs Dr. Smith's verification): this generic
-        # formula was verified to reproduce the exact same numeric
-        # values as the old hardcoded intensity_amplitude_factor and
-        # flux_amplitude_factor constants it replaces.
         """
         working_unit, working_power_unit = units.working_units(
             getattr(self, 'is_flux', False)
@@ -275,11 +270,6 @@ class PowerGaussian1D(Fittable1DModel):
     def _amplitude_factor(self):
         """Conversion factor from power to profile amplitude, computed
         for whichever unit track (flux or surface brightness) is active.
-
-        # ASSUMPTION (needs Dr. Smith's verification): this generic
-        # formula was verified to reproduce the exact same numeric
-        # values as the old hardcoded intensity_amplitude_factor and
-        # flux_amplitude_factor constants it replaces.
         """
         working_unit, working_power_unit = units.working_units(
             getattr(self, 'is_flux', False)

--- a/pahfit/fitters/ap_components.py
+++ b/pahfit/fitters/ap_components.py
@@ -166,25 +166,24 @@ class PowerDrude1D(Fittable1DModel):
     power = Parameter(min=0.0)
     x_0 = Parameter(min=0.0)
     fwhm = Parameter(default=1, min=0.0)
-    
-    # constant factors in the equation to convert power to amplitude of
-    # the profile. Two versions: one for surface brightness input
-    # (intensity_power -> intensity) and one for flux density input
-    # (flux_power -> flux_density).
-    intensity_amplitude_factor = (
-        (2 * units.intensity_power * units.wavelength / (constants.c * np.pi))
-        .to(units.intensity)
-        .value
-    )
 
-    # ASSUMPTION (needs Dr. Smith's verification): mirrors
-    # intensity_amplitude_factor above, substituting flux_power/
-    # flux_density. Dimensionally valid; not yet physically confirmed.
-    flux_amplitude_factor = (
-        (2 * units.flux_power * units.wavelength / (constants.c * np.pi))
-        .to(units.flux_density)
-        .value
-    )
+    def _amplitude_factor(self):
+        """Conversion factor from power to profile amplitude, computed
+        for whichever unit track (flux or surface brightness) is active.
+
+        # ASSUMPTION (needs Dr. Smith's verification): this generic
+        # formula was verified to reproduce the exact same numeric
+        # values as the old hardcoded intensity_amplitude_factor and
+        # flux_amplitude_factor constants it replaces.
+        """
+        working_unit, working_power_unit = units.working_units(
+            getattr(self, 'is_flux', False)
+        )
+        return (
+            (2 * working_power_unit * units.wavelength / (constants.c * np.pi))
+            .to(working_unit)
+            .value
+        )
 
     def evaluate(self, x, power, x_0, fwhm):
         """
@@ -229,8 +228,7 @@ class PowerDrude1D(Fittable1DModel):
         # factor = (2 * unit(power) * unit(wavelength) / (pi * c)).to(unit(intensity))
 
         g = fwhm / x_0
-        factor = self.flux_amplitude_factor if getattr(self, 'is_flux', False) else self.intensity_amplitude_factor
-        b = power * x_0 / g * factor
+        b = power * x_0 / g * self._amplitude_factor()
         return b * g**2 / ((x / x_0 - x_0 / x) ** 2 + g**2)
 
 
@@ -274,28 +272,27 @@ class PowerGaussian1D(Fittable1DModel):
     mean = Parameter()
     stddev = Parameter(default=1, min=0.0)
 
-    intensity_amplitude_factor = (
-        (
-            units.intensity_power
-            * (units.wavelength) ** 2
-            / (constants.c * units.wavelength * np.sqrt(2 * np.pi))
-        )
-        .to(units.intensity)
-        .value
-    )
+    def _amplitude_factor(self):
+        """Conversion factor from power to profile amplitude, computed
+        for whichever unit track (flux or surface brightness) is active.
 
-    # ASSUMPTION (needs Dr. Smith's verification): mirrors
-    # intensity_amplitude_factor above, substituting flux_power/
-    # flux_density. Dimensionally valid; not yet physically confirmed.
-    flux_amplitude_factor = (
-        (
-            units.flux_power
-            * (units.wavelength) ** 2
-            / (constants.c * units.wavelength * np.sqrt(2 * np.pi))
+        # ASSUMPTION (needs Dr. Smith's verification): this generic
+        # formula was verified to reproduce the exact same numeric
+        # values as the old hardcoded intensity_amplitude_factor and
+        # flux_amplitude_factor constants it replaces.
+        """
+        working_unit, working_power_unit = units.working_units(
+            getattr(self, 'is_flux', False)
         )
-        .to(units.flux_density)
-        .value
-    )
+        return (
+            (
+                working_power_unit
+                * (units.wavelength) ** 2
+                / (constants.c * units.wavelength * np.sqrt(2 * np.pi))
+            )
+            .to(working_unit)
+            .value
+        )
 
     def evaluate(self, x, power, mean, stddev):
         """
@@ -304,6 +301,5 @@ class PowerGaussian1D(Fittable1DModel):
         See class description for equations and unit notes."""
 
         # amplitude in intensity or flux density units
-        factor = self.flux_amplitude_factor if getattr(self, 'is_flux', False) else self.intensity_amplitude_factor
-        Anu = power * mean**2 / stddev * factor
+        Anu = power * mean**2 / stddev * self._amplitude_factor()
         return Anu * np.exp(-0.5 * np.square((x - mean) / stddev))

--- a/pahfit/fitters/ap_components.py
+++ b/pahfit/fitters/ap_components.py
@@ -171,14 +171,17 @@ class PowerDrude1D(Fittable1DModel):
         """Conversion factor from power to profile amplitude, computed
         for whichever unit track (flux or surface brightness) is active.
         """
-        working_unit, working_power_unit = units.working_units(
-            getattr(self, 'is_flux', False)
-        )
-        return (
-            (2 * working_power_unit * units.wavelength / (constants.c * np.pi))
-            .to(working_unit)
-            .value
-        )
+        is_flux = getattr(self, 'is_flux', False)
+        cached_is_flux = getattr(self, '_cached_is_flux', None)
+        if cached_is_flux != is_flux:
+            working_unit, working_power_unit = units.working_units(is_flux)
+            self._amplitude_factor_cache = (
+                (2 * working_power_unit * units.wavelength / (constants.c * np.pi))
+                .to(working_unit)
+                .value
+            )
+            self._cached_is_flux = is_flux
+        return self._amplitude_factor_cache
 
     def evaluate(self, x, power, x_0, fwhm):
         """
@@ -271,18 +274,21 @@ class PowerGaussian1D(Fittable1DModel):
         """Conversion factor from power to profile amplitude, computed
         for whichever unit track (flux or surface brightness) is active.
         """
-        working_unit, working_power_unit = units.working_units(
-            getattr(self, 'is_flux', False)
-        )
-        return (
-            (
-                working_power_unit
-                * (units.wavelength) ** 2
-                / (constants.c * units.wavelength * np.sqrt(2 * np.pi))
+        is_flux = getattr(self, 'is_flux', False)
+        cached_is_flux = getattr(self, '_cached_is_flux', None)
+        if cached_is_flux != is_flux:
+            working_unit, working_power_unit = units.working_units(is_flux)
+            self._amplitude_factor_cache = (
+                (
+                    working_power_unit
+                    * (units.wavelength) ** 2
+                    / (constants.c * units.wavelength * np.sqrt(2 * np.pi))
+                )
+                .to(working_unit)
+                .value
             )
-            .to(working_unit)
-            .value
-        )
+            self._cached_is_flux = is_flux
+        return self._amplitude_factor_cache
 
     def evaluate(self, x, power, mean, stddev):
         """

--- a/pahfit/fitters/ap_components.py
+++ b/pahfit/fitters/ap_components.py
@@ -167,21 +167,17 @@ class PowerDrude1D(Fittable1DModel):
     x_0 = Parameter(min=0.0)
     fwhm = Parameter(default=1, min=0.0)
 
-    def _amplitude_factor(self):
+    def _compute_amplitude_factor(self):
         """Conversion factor from power to profile amplitude, computed
         for whichever unit track (flux or surface brightness) is active.
         """
         is_flux = getattr(self, 'is_flux', False)
-        cached_is_flux = getattr(self, '_cached_is_flux', None)
-        if cached_is_flux != is_flux:
-            working_unit, working_power_unit = units.working_units(is_flux)
-            self._amplitude_factor_cache = (
-                (2 * working_power_unit * units.wavelength / (constants.c * np.pi))
-                .to(working_unit)
-                .value
-            )
-            self._cached_is_flux = is_flux
-        return self._amplitude_factor_cache
+        working_unit, working_power_unit = units.working_units(is_flux)
+        return (
+            (2 * working_power_unit * units.wavelength / (constants.c * np.pi))
+            .to(working_unit)
+            .value
+        )
 
     def evaluate(self, x, power, x_0, fwhm):
         """
@@ -226,7 +222,7 @@ class PowerDrude1D(Fittable1DModel):
         # factor = (2 * unit(power) * unit(wavelength) / (pi * c)).to(unit(intensity))
 
         g = fwhm / x_0
-        b = power * x_0 / g * self._amplitude_factor()
+        b = power * x_0 / g * self._amplitude_factor
         return b * g**2 / ((x / x_0 - x_0 / x) ** 2 + g**2)
 
 
@@ -270,25 +266,21 @@ class PowerGaussian1D(Fittable1DModel):
     mean = Parameter()
     stddev = Parameter(default=1, min=0.0)
 
-    def _amplitude_factor(self):
+    def _compute_amplitude_factor(self):
         """Conversion factor from power to profile amplitude, computed
         for whichever unit track (flux or surface brightness) is active.
         """
         is_flux = getattr(self, 'is_flux', False)
-        cached_is_flux = getattr(self, '_cached_is_flux', None)
-        if cached_is_flux != is_flux:
-            working_unit, working_power_unit = units.working_units(is_flux)
-            self._amplitude_factor_cache = (
-                (
-                    working_power_unit
-                    * (units.wavelength) ** 2
-                    / (constants.c * units.wavelength * np.sqrt(2 * np.pi))
-                )
-                .to(working_unit)
-                .value
+        working_unit, working_power_unit = units.working_units(is_flux)
+        return (
+            (
+                working_power_unit
+                * (units.wavelength) ** 2
+                / (constants.c * units.wavelength * np.sqrt(2 * np.pi))
             )
-            self._cached_is_flux = is_flux
-        return self._amplitude_factor_cache
+            .to(working_unit)
+            .value
+        )
 
     def evaluate(self, x, power, mean, stddev):
         """
@@ -297,5 +289,5 @@ class PowerGaussian1D(Fittable1DModel):
         See class description for equations and unit notes."""
 
         # amplitude in intensity or flux density units
-        Anu = power * mean**2 / stddev * self._amplitude_factor()
+        Anu = power * mean**2 / stddev * self._amplitude_factor
         return Anu * np.exp(-0.5 * np.square((x - mean) / stddev))

--- a/pahfit/fitters/ap_fitter.py
+++ b/pahfit/fitters/ap_fitter.py
@@ -270,6 +270,7 @@ class APFitter(Fitter):
         for c in components:
             if isinstance(c, (PowerDrude1D, PowerGaussian1D)):
                 c.is_flux = self.is_flux
+                c._amplitude_factor = c._compute_amplitude_factor()
 
         self.fit_info = []
 

--- a/pahfit/fitters/ap_fitter.py
+++ b/pahfit/fitters/ap_fitter.py
@@ -69,6 +69,7 @@ class APFitter(Fitter):
         self.feature_types = {}
         self.model = None
         self.message = None
+        self.is_flux = False
 
     def finalize(self):
         """Sum the registered components into one CompoundModel.
@@ -260,6 +261,15 @@ class APFitter(Fitter):
 
         # make sure there are no zero uncertainties either
         mask = np.isfinite(lam) & np.isfinite(flux) & np.isfinite(w)
+
+        if hasattr(self.model, "submodel_names"):
+            components = [self.model[name] for name in self.model.submodel_names]
+        else:
+            components = [self.model]
+
+        for c in components:
+            if isinstance(c, (PowerDrude1D, PowerGaussian1D)):
+                c.is_flux = self.is_flux
 
         self.fit_info = []
 

--- a/pahfit/fitters/ap_fitter.py
+++ b/pahfit/fitters/ap_fitter.py
@@ -69,7 +69,7 @@ class APFitter(Fitter):
         self.feature_types = {}
         self.model = None
         self.message = None
-        self.is_flux = False
+        self.is_flux = None
         self.fit_info = None
         self.methods = ["lm", "trf"]
 
@@ -267,8 +267,9 @@ class APFitter(Fitter):
 
         for c in components:
             if isinstance(c, (PowerDrude1D, PowerGaussian1D)):
-                c.is_flux = self.is_flux
-                c._amplitude_factor = c._compute_amplitude_factor()
+                if getattr(c, 'is_flux', None) != self.is_flux:
+                    c.is_flux = self.is_flux
+                    c._amplitude_factor = c._compute_amplitude_factor()
 
         self.fit_info = []
         if method_str not in self.methods:

--- a/pahfit/fitters/ap_fitter.py
+++ b/pahfit/fitters/ap_fitter.py
@@ -288,7 +288,7 @@ class APFitter(Fitter):
             self.model,
             lam[mask],
             flux[mask],
-            weights=w[mask],
+            w=w[mask],
             maxiter=maxiter,
             epsilon=1e-10,
             acc=1e-10)

--- a/pahfit/fitters/ap_fitter.py
+++ b/pahfit/fitters/ap_fitter.py
@@ -287,7 +287,7 @@ class APFitter(Fitter):
             self.model,
             lam[mask],
             flux[mask],
-            w=w[mask],
+            weights=w[mask],
             maxiter=maxiter,
             epsilon=1e-10,
             acc=1e-10)

--- a/pahfit/helpers.py
+++ b/pahfit/helpers.py
@@ -86,7 +86,7 @@ def read_spectrum(specfile, format=None):
     # Convert to intensity units by assuming an arbitrary solid angle
     # for now. To be removed when dual unit support (intensity and flux
     # density) is supported.
-    if s.flux.unit.is_equivalent(units.flux_density):
+    if not units.is_surface_brightness(s.flux.unit):
         solid_angle = (3 * u.arcsec) ** 2
         alt_flux = (s.flux / solid_angle).to(units.intensity)
         alt_unc_array = (s.uncertainty.array * s.flux.unit / solid_angle).to(

--- a/pahfit/helpers.py
+++ b/pahfit/helpers.py
@@ -58,7 +58,8 @@ def read_spectrum(specfile, format=None):
     Returns
     -------
     spec1d : Spectrum1D
-        spectral_axis in microns, flux and uncertainties in units of Jy
+        spectral_axis in microns; flux and uncertainties kept in their
+        native units (flux density or surface brightness)
     """
     # resolve filename
     if not os.path.isfile(specfile):
@@ -82,18 +83,5 @@ def read_spectrum(specfile, format=None):
         tformat = format
 
     s = Spectrum1D.read(specfile, format=tformat)
-
-    # Convert to intensity units by assuming an arbitrary solid angle
-    # for now. To be removed when dual unit support (intensity and flux
-    # density) is supported.
-    if not units.is_surface_brightness(s.flux.unit):
-        solid_angle = (3 * u.arcsec) ** 2
-        alt_flux = (s.flux / solid_angle).to(units.intensity)
-        alt_unc_array = (s.uncertainty.array * s.flux.unit / solid_angle).to(
-            units.intensity
-        )
-        s = Spectrum1D(
-            alt_flux, s.spectral_axis, uncertainty=StdDevUncertainty(alt_unc_array)
-        )
 
     return s

--- a/pahfit/model.py
+++ b/pahfit/model.py
@@ -187,16 +187,10 @@ class Model:
         lam_min = min(lam)
         lam_max = max(lam)
 
-        # Pick the working unit and power unit based on the actual
-        # input type, so initial guesses aren't scaled as if flux
-        # data were surface brightness (same pattern as elsewhere
-        # in this PR -- see is_flux in ap_fitter.py).
-        if units.is_surface_brightness(spec.flux.unit):
-            working_unit = units.intensity
-            working_power_unit = units.intensity_power
-        else:
-            working_unit = units.flux_density
-            working_power_unit = units.flux_power
+        # Working unit and power unit chosen based on input type --
+        # see units.working_units().
+        is_flux = not units.is_surface_brightness(spec.flux.unit)
+        working_unit, working_power_unit = units.working_units(is_flux)
 
         # Some useful quantities for guessing
         median_flux = np.median(flux)
@@ -339,22 +333,24 @@ class Model:
             corrected for redshift
 
         """
-        # ASSUMPTION (revisit w/ Dr. Smith): choose the working unit from
-        # the input. Surface brightness -> MJy/sr, flux density -> mJy.
-        # The fitter operates on bare numbers, so it doesn't care which,
-        # as long as we convert consistently here.
-        if units.is_surface_brightness(spec.flux.unit):
-            working_unit = units.intensity        # MJy / sr
-        elif spec.flux.unit.is_equivalent(units.flux_density):
-            working_unit = units.flux_density     # mJy
-        else:
+        # Working unit chosen based on input type -- see
+        # units.working_units().
+        is_flux = not units.is_surface_brightness(spec.flux.unit)
+        if is_flux and not spec.flux.unit.is_equivalent(
+            units.flux_density, equivalencies=u.spectral_density(spec.spectral_axis)
+        ):
             raise PAHFITModelError(
-                "PAHFIT input must be a flux density (e.g. mJy) or a "
-                "surface brightness (e.g. MJy / sr)."
+                "PAHFIT input must be a flux density (e.g. mJy or erg/s/cm^2/Angstrom) "
+                "or a surface brightness (e.g. MJy / sr)."
             )
-        flux_obs = spec.flux.to(working_unit).value
+        working_unit, _ = units.working_units(is_flux)
+        flux_obs = spec.flux.to(
+            working_unit, equivalencies=u.spectral_density(spec.spectral_axis)
+        ).value
         lam_obs = spec.spectral_axis.to(u.micron).value
-        unc_obs = (spec.uncertainty.array * spec.flux.unit).to(working_unit).value
+        unc_obs = (spec.uncertainty.array * spec.flux.unit).to(
+            working_unit, equivalencies=u.spectral_density(spec.spectral_axis)
+        ).value
 
         # transform observed wavelength to "physical" wavelength
         lam = lam_obs / (1 + z)  # wavelength shorter

--- a/pahfit/model.py
+++ b/pahfit/model.py
@@ -328,13 +328,22 @@ class Model:
             corrected for redshift
 
         """
-        if not spec.flux.unit.is_equivalent(units.intensity):
+        # ASSUMPTION (revisit w/ Dr. Smith): choose the working unit from
+        # the input. Surface brightness -> MJy/sr, flux density -> mJy.
+        # The fitter operates on bare numbers, so it doesn't care which,
+        # as long as we convert consistently here.
+        if units.is_surface_brightness(spec.flux.unit):
+            working_unit = units.intensity        # MJy / sr
+        elif spec.flux.unit.is_equivalent(units.flux_density):
+            working_unit = units.flux_density     # mJy
+        else:
             raise PAHFITModelError(
-                "For now, PAHFIT only supports intensity units, i.e. convertible to MJy / sr."
+                "PAHFIT input must be a flux density (e.g. mJy) or a "
+                "surface brightness (e.g. MJy / sr)."
             )
-        flux_obs = spec.flux.to(units.intensity).value
+        flux_obs = spec.flux.to(working_unit).value
         lam_obs = spec.spectral_axis.to(u.micron).value
-        unc_obs = (spec.uncertainty.array * spec.flux.unit).to(units.intensity).value
+        unc_obs = (spec.uncertainty.array * spec.flux.unit).to(working_unit).value
 
         # transform observed wavelength to "physical" wavelength
         lam = lam_obs / (1 + z)  # wavelength shorter

--- a/pahfit/model.py
+++ b/pahfit/model.py
@@ -2,7 +2,6 @@ from specutils import Spectrum1D
 from astropy import units as u
 from astropy import constants
 import copy
-import warnings
 import matplotlib as mpl
 from matplotlib import pyplot as plt
 import numpy as np

--- a/pahfit/model.py
+++ b/pahfit/model.py
@@ -413,8 +413,11 @@ class Model:
 
         # check if observed spectrum is compatible with instrument model
         instrument.check_range([min(x), max(x)], inst)
-
         self._set_up_fitter(inst, z, lam=x, use_instrument_fwhm=use_instrument_fwhm)
+
+        # Detect flux vs. surface brightness and set flag on fitter
+        # so Power* components can select the correct amplitude factor.
+        self.fitter.is_flux = not units.is_surface_brightness(spec.flux.unit)
         self.fitter.fit(lam, flux, unc, maxiter=maxiter)
 
         # copy the fit results to the features table
@@ -430,16 +433,18 @@ class Model:
         where Fitter.fit() has been applied.
 
         """
-        # ASSUMPTION (flag for Dr. Smith): power values are only
-        # calculated correctly for surface-brightness input right now.
-        # If the input was flux, warn instead of silently mislabeling.
+        """
+        Power values are now computed correctly for both flux and
+        surface-brightness input (see PowerDrude1D/PowerGaussian1D).
+        The features table's 'power' column is stamped with a default
+        unit at table-creation time (before any spectrum is loaded),
+        so we correct that label here, after the fit, based on what
+        kind of input was actually used.
+
+        """
         if not units.is_surface_brightness(self.features.meta["user_unit"]["flux"]):
-            warnings.warn(
-                "Input spectrum is flux density (not surface brightness). "
-                "Fitted 'power' values are not yet dimensionally correct "
-                "for this case — this is a known limitation, not a bug in "
-                "your data. See PowerDrude1D/PowerGaussianSum1D docstring."
-            )
+            self.features["power"].unit = units.flux_power
+            
             
         # iterate over the list stored in fitter, so we only get
         # components that were set up by _set_up_fitter. Having an

--- a/pahfit/model.py
+++ b/pahfit/model.py
@@ -463,10 +463,12 @@ class Model:
         kind of input was actually used.
 
         """
-        if not units.is_surface_brightness(self.features.meta["user_unit"]["flux"]):
+        if units.is_surface_brightness(self.features.meta["user_unit"]["flux"]):
+            self.features["power"].unit = units.intensity_power
+        else:
             self.features["power"].unit = units.flux_power
-            
-            
+
+
         # iterate over the list stored in fitter, so we only get
         # components that were set up by _set_up_fitter. Having an
         # ENABLED/DISABLED flag for every feature would be a nice

--- a/pahfit/model.py
+++ b/pahfit/model.py
@@ -2,6 +2,7 @@ from specutils import Spectrum1D
 from astropy import units as u
 from astropy import constants
 import copy
+import warnings
 import matplotlib as mpl
 from matplotlib import pyplot as plt
 import numpy as np
@@ -429,6 +430,17 @@ class Model:
         where Fitter.fit() has been applied.
 
         """
+        # ASSUMPTION (flag for Dr. Smith): power values are only
+        # calculated correctly for surface-brightness input right now.
+        # If the input was flux, warn instead of silently mislabeling.
+        if not units.is_surface_brightness(self.features.meta["user_unit"]["flux"]):
+            warnings.warn(
+                "Input spectrum is flux density (not surface brightness). "
+                "Fitted 'power' values are not yet dimensionally correct "
+                "for this case — this is a known limitation, not a bug in "
+                "your data. See PowerDrude1D/PowerGaussianSum1D docstring."
+            )
+            
         # iterate over the list stored in fitter, so we only get
         # components that were set up by _set_up_fitter. Having an
         # ENABLED/DISABLED flag for every feature would be a nice

--- a/pahfit/model.py
+++ b/pahfit/model.py
@@ -188,9 +188,20 @@ class Model:
         lam_min = min(lam)
         lam_max = max(lam)
 
+        # Pick the working unit and power unit based on the actual
+        # input type, so initial guesses aren't scaled as if flux
+        # data were surface brightness (same pattern as elsewhere
+        # in this PR -- see is_flux in ap_fitter.py).
+        if units.is_surface_brightness(spec.flux.unit):
+            working_unit = units.intensity
+            working_power_unit = units.intensity_power
+        else:
+            working_unit = units.flux_density
+            working_power_unit = units.flux_power
+
         # Some useful quantities for guessing
         median_flux = np.median(flux)
-        Flambda = flux * units.intensity * (lam * units.wavelength) ** -2 * constants.c
+        Flambda = flux * working_unit * (lam * units.wavelength) ** -2 * constants.c
         total_power = integrate.trapezoid(Flambda, lam * units.wavelength)
 
         # simple linear interpolation function for spectrum
@@ -269,15 +280,15 @@ class Model:
             # this is an unphysical power (Fnu * dlambda), but we
             # convert to Fnu dnu = Fnu dnu/dlambda dlambda = Fnu c /
             # lambda **2 dlambda
-            Fnu_dlambda *= units.intensity * units.wavelength
+            Fnu_dlambda *= working_unit * units.wavelength
             Fnu_dnu = Fnu_dlambda * constants.c / (lam_line * units.wavelength) ** 2
-            return Fnu_dnu.to(units.intensity_power).value
+            return Fnu_dnu.to(working_power_unit).value
 
         def drude_power_guess(row):
             # multiply total power by some fraction to guess Drude power
             fwhm = row["fwhm"][0] * units.wavelength
             delta_w = spec.spectral_axis[-1] - spec.spectral_axis[0]
-            return (total_power * fwhm / delta_w).to(units.intensity_power).value
+            return (total_power * fwhm / delta_w).to(working_power_unit).value
 
         loop_over_non_fixed("dust_feature", "power", drude_power_guess)
 

--- a/pahfit/units.py
+++ b/pahfit/units.py
@@ -15,3 +15,16 @@ intensity_power = CompositeUnit(1e-10, (u.W, u.m, u.sr), (1, -2, -1))
 # Note: integrated power units of 1e-22 W/m^2 (from flux) corresponds
 # to the unit 1e-10 W/m^2/sr (from intensity) if it occurs uniformly
 # over a solid angle 0.21" on a side (about a small JWST IFU pixel)
+
+def is_surface_brightness(unit):
+    """Return True if `unit` is a surface brightness, False if a flux.
+
+    Surface brightness units carry a per-solid-angle component (e.g.
+    MJy/sr). We detect this by decomposing the unit to its base units
+    and checking for an inverse-solid-angle term. Steradian decomposes
+    to rad**2, so "per steradian" shows up as (u.rad, -2).
+
+    Method suggested by J.D. Smith in issue #28.
+    """
+    decomposed = unit.decompose()
+    return (u.rad, -2) in zip(decomposed.bases, decomposed.powers)

--- a/pahfit/units.py
+++ b/pahfit/units.py
@@ -27,12 +27,17 @@ def is_surface_brightness(unit):
 def get_quantity(features, name, column):
     """Get one feature's parameter value with its unit attached
     (e.g. "5.2 mJy"). Returns None if masked, instead of an
-    incorrect 0."""
-
+    incorrect 0. Columns with no assigned unit (e.g. tau, which
+    is dimensionless) are returned as plain dimensionless
+    Quantities, not multiplied against None.
+    """
     row = features.loc[name]
     if row[column] is np.ma.masked:
         return None
-    return row[column]["val"] * features[column].unit
+    unit = features[column].unit
+    if unit is None:
+        unit = u.dimensionless_unscaled
+    return row[column]["val"] * unit
 
 
 def working_units(is_flux):

--- a/pahfit/units.py
+++ b/pahfit/units.py
@@ -33,3 +33,18 @@ def get_quantity(features, name, column):
     if row[column] is np.ma.masked:
         return None
     return row[column]["val"] * features[column].unit
+
+
+def working_units(is_flux):
+    """Return (value_unit, power_unit) for the given track.
+
+    is_flux=True  -> (flux_density, flux_power)       e.g. mJy, 1e-22 W/m^2
+    is_flux=False -> (intensity, intensity_power)      e.g. MJy/sr, 1e-10 W/m^2/sr
+
+    Centralizes the flux-vs-surface-brightness unit choice that was
+    previously duplicated across _convert_spec_data, guess(), and the
+    Power* fitting components.
+    """
+    if is_flux:
+        return flux_density, flux_power
+    return intensity, intensity_power

--- a/pahfit/units.py
+++ b/pahfit/units.py
@@ -1,3 +1,4 @@
+import numpy as np
 import astropy.units as u
 from astropy.units import CompositeUnit
 
@@ -43,8 +44,13 @@ def get_quantity(features, name, column):
 
     Returns
     -------
-    astropy.units.Quantity
+    astropy.units.Quantity, or None
         The fitted value, with its unit attached (e.g. "5.2 mJy").
+        Returns None if this parameter is masked (not set/not
+        applicable) for this feature, instead of silently returning
+        an incorrect 0.
     """
     row = features.loc[name]
+    if row[column] is np.ma.masked:
+        return None
     return row[column]["val"] * features[column].unit

--- a/pahfit/units.py
+++ b/pahfit/units.py
@@ -18,38 +18,17 @@ intensity_power = CompositeUnit(1e-10, (u.W, u.m, u.sr), (1, -2, -1))
 # over a solid angle 0.21" on a side (about a small JWST IFU pixel)
 
 def is_surface_brightness(unit):
-    """Return True if `unit` is a surface brightness, False if a flux.
+    """True if `unit` is a surface brightness (has 1/sr), False if a flux.
+    Method suggested by J.D. Smith in issue #28."""
 
-    Surface brightness units carry a per-solid-angle component (e.g.
-    MJy/sr). We detect this by decomposing the unit to its base units
-    and checking for an inverse-solid-angle term. Steradian decomposes
-    to rad**2, so "per steradian" shows up as (u.rad, -2).
-
-    Method suggested by J.D. Smith in issue #28.
-    """
     decomposed = unit.decompose()
     return (u.rad, -2) in zip(decomposed.bases, decomposed.powers)
 
 def get_quantity(features, name, column):
-    """Get one feature's parameter value, with its unit attached.
+    """Get one feature's parameter value with its unit attached
+    (e.g. "5.2 mJy"). Returns None if masked, instead of an
+    incorrect 0."""
 
-    Parameters
-    ----------
-    features : Features table
-        The PAHFIT features table (e.g. model.features).
-    name : str
-        Feature name, e.g. '[NeII]'.
-    column : str
-        Parameter name, e.g. 'power', 'wavelength', 'fwhm'.
-
-    Returns
-    -------
-    astropy.units.Quantity, or None
-        The fitted value, with its unit attached (e.g. "5.2 mJy").
-        Returns None if this parameter is masked (not set/not
-        applicable) for this feature, instead of silently returning
-        an incorrect 0.
-    """
     row = features.loc[name]
     if row[column] is np.ma.masked:
         return None

--- a/pahfit/units.py
+++ b/pahfit/units.py
@@ -28,3 +28,23 @@ def is_surface_brightness(unit):
     """
     decomposed = unit.decompose()
     return (u.rad, -2) in zip(decomposed.bases, decomposed.powers)
+
+def get_quantity(features, name, column):
+    """Get one feature's parameter value, with its unit attached.
+
+    Parameters
+    ----------
+    features : Features table
+        The PAHFIT features table (e.g. model.features).
+    name : str
+        Feature name, e.g. '[NeII]'.
+    column : str
+        Parameter name, e.g. 'power', 'wavelength', 'fwhm'.
+
+    Returns
+    -------
+    astropy.units.Quantity
+        The fitted value, with its unit attached (e.g. "5.2 mJy").
+    """
+    row = features.loc[name]
+    return row[column]["val"] * features[column].unit


### PR DESCRIPTION
## Summary

Adds dual-unit support to PAHFIT (#28): accepts both flux-density (Jy, mJy,
and now wavelength-based units like erg/s/cm²/Å) and surface-brightness
(MJy/sr) input, converts correctly internally, and labels output units
based on what was actually used.

## What's done

- Detects flux vs. surface brightness input (`is_surface_brightness()`)
- Accepts flux spectra instead of rejecting them; removed the old fake
  solid-angle workaround
- Fitting math and initial guesses use the correct flux/intensity factors
  based on input type, via a shared `working_units()` helper (replacing
  duplicated logic across `_convert_spec_data`, `guess()`, and the
  `Power*` fitting components)
- `PowerDrude1D`/`PowerGaussian1D` now compute their amplitude factor
  generically at evaluate time, instead of two separate hardcoded
  constants per class
- Wavelength-based flux units (e.g. `erg/s/cm²/Å`) now supported via
  `astropy`'s `spectral_density` equivalency
- `power` column labels itself correctly after fitting
- Added `get_quantity()` to pull a table value with its unit attached,
  including graceful handling of masked values (`None`, not a fake `0`)
  and dimensionless columns like `tau` (previously crashed)

## Testing

Tested end-to-end on real M83 data, both input types. Surface-brightness
results unchanged from before this PR. Flux results cross-checked against
surface-brightness results via implied solid angle which was consistent to ~2-3%
across two features. `get_quantity()` tested across every feature and
every numeric column in a real fitted table (265 checks, 0 errors).
This testing caught and fixed the `tau` crash above.

## Open questions

- Uncertainty support via `get_quantity()` is out of scope for this PR. It will be
  tracked as a separate future PR, pending the covariance matrix work.