### PR TITLE
   Fix w=/weights= keyword argument in APFitter.fit()

### DIFF
--- a/pahfit/fitters/ap_fitter.py
+++ b/pahfit/fitters/ap_fitter.py
@@ -275,7 +275,7 @@ class APFitter(Fitter):
             self.model,
             lam[mask],
             flux[mask],
-            w=w[mask],
+            weights=w[mask],
             maxiter=maxiter,
             epsilon=1e-10,
             acc=1e-10)


### PR DESCRIPTION
In `ap_fitter.py`, `fit()` was passing `w=` to astropy's fitter, but astropy's fitter classes expect `weights=`. This caused a TypeError ("got an unexpected keyword argument 'w'") whenever `fit()` was called. It's a one-line fix.

I found this while merging PR #321 (units support) with the new dev version (after PR #317 was merged).